### PR TITLE
feat: Phase 1 & 2 — code quality, config refactor, resilience

### DIFF
--- a/.github/agents/ui-improvements.agent.md
+++ b/.github/agents/ui-improvements.agent.md
@@ -1,221 +1,500 @@
 ---
 name: "UI Improvements"
-description: "Fixes the stackd dashboard: corrects the stacks-vs-containers data model, adds a commit history panel, enables multi-container log selection, and implements dark mode."
+description: "Full modernisation of the stackd dashboard: restore repo/stack hierarchy, bigger logo, force git sync per repo, Docker container env vars, container tabs with logs/env/info, modern styling, and live auto-refresh."
 tools: ["search", "read_file", "edit_file", "run_terminal_command"]
 model: "claude-sonnet-4.6"
 ---
 
 # stackd UI Improvements Agent
 
-You are a Preact/JavaScript engineer for **stackd**. The dashboard has several UX
-problems stemming from a data model confusion and missing features. Your job is to
-fix them.
+You are a Preact/JavaScript engineer for **stackd**. A thorough UX audit has been
+completed. Your job is to implement the full modernisation of the dashboard.
 
-**Prerequisite:** All backend agents (Phases 1–3) must have completed, since some UI
-fixes depend on new API fields (e.g., last commit SHA from `@config-refactor`).
+**Prerequisite:** All backend agents (Phases 1–3) must have completed.
 
-## Context: Current Data Model Problem
+## Audit Findings Summary
 
-The current `app.jsx` extracts containers from stacks and displays them as "Applications":
+Critical issues found:
+1. Data model is wrong — flattens repos→stacks→containers into a flat list; all context lost
+2. Force sync button missing — POST /api/sync/{repo} exists but is never called
+3. Logo is only 40px height — barely visible
+4. No env vars shown — needs backend + frontend work
+5. No auto-refresh — data goes stale after mount
+6. HTML title still says "SimpleGithubSync"
+7. Container uptime (startedAt) available but unused
+8. Log timestamps and level colours missing — CSS classes exist but unused
+9. Silent failure if API is down — no error state
 
-```jsx
-// WRONG: iterates containers, not stacks
-const apps = repos.flatMap(repo =>
-  repo.stacks.flatMap(stack => stack.containers)
-);
-```
+---
 
-Then `AppGrid` renders "Applications" with container names, images, and statuses.
-When you click a container, `AppDetail` streams logs for that container.
+## Backend Changes Required First
 
-**The correct mental model:**
-- A **repo** contains one or more **stacks** (compose projects)
-- A **stack** contains one or more **containers**
-- The primary entity users care about is the **stack**, not the container
-- Log streaming is fine at the container level, but navigation should be stack-first
+### A. Add Env and Ports to ContainerDetail in internal/state/state.go
 
-## Task 1 — Fix the Data Hierarchy in `app.jsx`
-
-Rewrite the data extraction in `app.jsx` so the primary list is **stacks**, not containers:
-
-```jsx
-// CORRECT: display stacks as the primary entities
-const stacks = repos.flatMap(repo =>
-  repo.stacks.map(stack => ({ ...stack, repoName: repo.name }))
-);
-```
-
-Pass `stacks` to `AppGrid` (not containers). `AppGrid` shows one card per stack.
-
-Each stack card should display:
-- Stack name (directory basename)
-- Repo name (smaller, secondary label)
-- Composite status: `running` (all containers running), `degraded` (some stopped), `error`, `syncing`
-- Last applied timestamp (`stack.lastApply`)
-- Last commit SHA (first 7 chars) if available (`stack.lastSHA` — add this field to the API)
-- List of containers with individual statuses (collapsed by default, expandable)
-
-## Task 2 — Fix `AppGrid.jsx` to Show Stack Cards
-
-Rewrite `AppGrid.jsx` to render **stack cards** (not container cards):
-
-```jsx
-// AppGrid.jsx — one card per stack
-export function AppGrid({ stacks, onSelectStack }) {
-  return (
-    <div class="app-grid">
-      {stacks.map(stack => (
-        <StackCard
-          key={`${stack.repoName}/${stack.name}`}
-          stack={stack}
-          onSelect={() => onSelectStack(stack)}
-        />
-      ))}
-    </div>
-  );
-}
-
-function StackCard({ stack, onSelect }) {
-  const status = deriveStackStatus(stack.containers);
-  return (
-    <div class={`stack-card stack-card--${status}`} onClick={onSelect}>
-      <div class="stack-card__name">{stack.name}</div>
-      <div class="stack-card__repo">{stack.repoName}</div>
-      <div class="stack-card__status">{status}</div>
-      <div class="stack-card__meta">
-        {stack.lastApply && <span>Applied {formatRelative(stack.lastApply)}</span>}
-        {stack.lastSHA && <span class="stack-card__sha">{stack.lastSHA.slice(0, 7)}</span>}
-      </div>
-      <ContainerList containers={stack.containers} />
-    </div>
-  );
+```go
+type ContainerDetail struct {
+    ID        string    `json:"id"`
+    Name      string    `json:"name"`
+    Image     string    `json:"image"`
+    Status    string    `json:"status"`
+    StartedAt time.Time `json:"startedAt"`
+    Env       []string  `json:"env"`   // ["KEY=value", ...] — sensitive values masked
+    Ports     []string  `json:"ports"` // ["8080:80/tcp", ...]
 }
 ```
 
-`deriveStackStatus(containers)`:
-- All running → `"running"`
-- Any stopped → `"degraded"`
-- Stack status === "error" → `"error"`
-- Otherwise → `"unknown"`
+### B. Populate Env and Ports in internal/docker/client.go
 
-## Task 3 — Multi-Container Log Selection in `AppDetail.jsx`
+In ListStackContainerDetails(), extract from ContainerInspect result:
+- container.Config.Env → filter secrets (mask keys containing TOKEN, SECRET, KEY, PASSWORD, PASS)
+- container.NetworkSettings.Ports → format as "hostPort:containerPort/proto"
 
-When a user clicks a stack, `AppDetail` currently shows a single container's logs.
-Update it to show a **container selector** so users can switch between containers:
-
-```jsx
-export function AppDetail({ stack, onClose }) {
-  const [selectedContainer, setSelectedContainer] = useState(
-    stack.containers[0]?.name ?? null
-  );
-
-  return (
-    <div class="app-detail">
-      <div class="app-detail__header">
-        <h2>{stack.name}</h2>
-        <button onClick={onClose}>✕</button>
-      </div>
-
-      {/* Container selector tabs */}
-      <div class="app-detail__tabs">
-        {stack.containers.map(c => (
-          <button
-            key={c.name}
-            class={`tab ${c.name === selectedContainer ? 'tab--active' : ''}`}
-            onClick={() => setSelectedContainer(c.name)}
-          >
-            {c.name}
-            <span class={`tab__dot tab__dot--${c.status}`} />
-          </button>
-        ))}
-      </div>
-
-      {/* Log stream for selected container */}
-      {selectedContainer && (
-        <LogStream container={selectedContainer} />
-      )}
-    </div>
-  );
+Masking helper:
+```go
+func maskEnvVars(envs []string) []string {
+    sensitiveSubstrings := []string{"TOKEN", "SECRET", "KEY", "PASSWORD", "PASS", "CREDENTIAL"}
+    result := make([]string, 0, len(envs))
+    for _, e := range envs {
+        parts := strings.SplitN(e, "=", 2)
+        if len(parts) == 2 {
+            upper := strings.ToUpper(parts[0])
+            masked := false
+            for _, sub := range sensitiveSubstrings {
+                if strings.Contains(upper, sub) {
+                    result = append(result, parts[0]+"=[redacted]")
+                    masked = true
+                    break
+                }
+            }
+            if !masked {
+                result = append(result, e)
+            }
+        } else {
+            result = append(result, e)
+        }
+    }
+    return result
 }
 ```
 
-Extract the log streaming logic from the current `AppDetail` into a separate
-`LogStream` component that takes a `container` prop and starts/stops the `EventSource`
-when the prop changes (use `useEffect` with `container` as dependency).
-
-## Task 4 — Repo Status Panel
-
-Add a small **Repos** sidebar or header panel showing repo sync status:
-
-```jsx
-function RepoStatus({ repos }) {
-  return (
-    <div class="repo-status">
-      {repos.map(repo => (
-        <div key={repo.name} class={`repo-status__item repo-status__item--${repo.status}`}>
-          <span class="repo-status__name">{repo.name}</span>
-          <span class="repo-status__sha">{repo.lastSHA?.slice(0, 7)}</span>
-          <span class="repo-status__time">{formatRelative(repo.lastSync)}</span>
-          <button class="repo-status__sync" onClick={() => triggerSync(repo.name)}>↻</button>
-        </div>
-      ))}
-    </div>
-  );
-}
-```
-
-This replaces or augments the current sync button.
-
-## Task 5 — Dark Mode
-
-Add a dark mode toggle. Use CSS custom properties for all colors:
-
-```css
-/* index.css */
-:root {
-  --color-bg: #ffffff;
-  --color-surface: #f5f5f5;
-  --color-text: #1a1a1a;
-  --color-text-secondary: #666;
-  --color-border: #e0e0e0;
-  --color-running: #22c55e;
-  --color-degraded: #f59e0b;
-  --color-error: #ef4444;
-  --color-accent: #6366f1;
-}
-
-[data-theme="dark"] {
-  --color-bg: #0f0f0f;
-  --color-surface: #1a1a1a;
-  --color-text: #f5f5f5;
-  --color-text-secondary: #999;
-  --color-border: #2a2a2a;
-}
-```
-
-Toggle: button in the header, stores preference in `localStorage` as `stackd_theme`.
-Apply `document.documentElement.setAttribute('data-theme', theme)` on load and toggle.
-
-## Task 6 — Build Verification
-
-After changes, verify the frontend builds and the binary embeds it correctly:
-
+### C. Verify backend builds
 ```bash
-cd internal/ui
-npm install
-npm run build
-cd ../..
 go build ./...
 ```
 
-The binary must start and serve the updated dashboard without errors.
+---
+
+## Frontend Changes
+
+All files are in internal/ui/src/.
+
+### Task 1 — Fix HTML title (index.html)
+```html
+<title>stackd</title>
+<meta name="description" content="GitOps dashboard for Docker Compose deployments">
+<meta name="theme-color" content="#1a1a1a">
+```
+
+### Task 2 — Rewrite App.jsx
+
+Keep full repo→stack hierarchy. Add auto-refresh every 5s. Add force sync handler.
+
+```jsx
+import { useState, useEffect } from 'preact/hooks'
+import { AppGrid } from './components/AppGrid'
+import { AppDetail } from './components/AppDetail'
+
+export function App() {
+  const [repos, setRepos] = useState([])
+  const [infisical, setInfisical] = useState(null)
+  const [selectedStack, setSelectedStack] = useState(null)
+  const [error, setError] = useState(null)
+  const [syncingRepos, setSyncingRepos] = useState(new Set())
+
+  const fetchStatus = () => {
+    fetch('/api/status')
+      .then(r => r.json())
+      .then(data => { setRepos(data.repos || []); setInfisical(data.infisical); setError(null) })
+      .catch(err => setError(err.message))
+  }
+
+  useEffect(() => {
+    fetchStatus()
+    const interval = setInterval(fetchStatus, 5000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const handleForceSync = (repoName) => {
+    setSyncingRepos(prev => new Set([...prev, repoName]))
+    fetch(`/api/sync/${repoName}`, { method: 'POST' })
+      .finally(() => setTimeout(() => {
+        setSyncingRepos(prev => { const s = new Set(prev); s.delete(repoName); return s })
+      }, 3000))
+  }
+
+  return (
+    <div class="app-shell">
+      <header class="app-header">
+        <div class="app-header__brand">
+          <img src="/logo.svg" alt="stackd" class="app-logo" />
+        </div>
+        <div class="app-header__meta">
+          {infisical?.enabled && (
+            <span class="infisical-badge">🔒 Infisical: {infisical.env}</span>
+          )}
+        </div>
+      </header>
+
+      {error && (
+        <div class="error-banner">
+          <span>⚠ Failed to load: {error}</span>
+          <button onClick={fetchStatus}>Retry</button>
+        </div>
+      )}
+
+      <div class="app-container">
+        <div class="grid-panel">
+          <AppGrid
+            repos={repos}
+            selectedStack={selectedStack}
+            syncingRepos={syncingRepos}
+            onSelectStack={setSelectedStack}
+            onForceSync={handleForceSync}
+          />
+        </div>
+        {selectedStack && (
+          <div class="detail-panel">
+            <AppDetail stack={selectedStack} onClose={() => setSelectedStack(null)} />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+### Task 3 — Rewrite AppGrid.jsx with repo/stack/container hierarchy
+
+Show Repo groups → Stack cards → container count. Force sync button per repo.
+
+```jsx
+import { formatRelative } from '../utils/time'
+
+export function AppGrid({ repos, selectedStack, syncingRepos, onSelectStack, onForceSync }) {
+  if (!repos.length) {
+    return (
+      <div class="empty-state">
+        <p>No repositories found.</p>
+        <p class="empty-state__hint">Mount git repos into REPOS_DIR to get started.</p>
+      </div>
+    )
+  }
+  return (
+    <div class="app-grid">
+      {repos.map(repo => (
+        <RepoGroup key={repo.name} repo={repo} selectedStack={selectedStack}
+          isSyncing={syncingRepos.has(repo.name)} onSelectStack={onSelectStack} onForceSync={onForceSync} />
+      ))}
+    </div>
+  )
+}
+
+function RepoGroup({ repo, selectedStack, isSyncing, onSelectStack, onForceSync }) {
+  return (
+    <div class="repo-group">
+      <div class="repo-header">
+        <div class="repo-header__left">
+          <span class={`repo-status-dot repo-status-dot--${repo.status}`} />
+          <span class="repo-name">{repo.name}</span>
+          {repo.lastSha && <span class="repo-sha">{repo.lastSha.slice(0, 7)}</span>}
+        </div>
+        <div class="repo-header__right">
+          {repo.lastSync && <span class="repo-last-sync">{formatRelative(repo.lastSync)}</span>}
+          <button class={`sync-btn ${isSyncing ? 'sync-btn--spinning' : ''}`}
+            onClick={() => onForceSync(repo.name)} title="Force git sync" disabled={isSyncing}>↻</button>
+        </div>
+      </div>
+      {repo.lastError && <div class="repo-error">{repo.lastError}</div>}
+      <div class="stack-list">
+        {(repo.stacks || []).map(stack => (
+          <StackCard key={stack.name} stack={stack} repoName={repo.name}
+            isSelected={selectedStack?.name === stack.name && selectedStack?.repoName === repo.name}
+            onSelect={() => onSelectStack({ ...stack, repoName: repo.name })} />
+        ))}
+        {(!repo.stacks || !repo.stacks.length) && <div class="empty-stacks">No stacks configured</div>}
+      </div>
+    </div>
+  )
+}
+
+function StackCard({ stack, isSelected, onSelect }) {
+  const status = deriveStackStatus(stack)
+  const running = (stack.containers || []).filter(c => c.status === 'running').length
+  const total = (stack.containers || []).length
+  return (
+    <div class={`stack-card stack-card--${status} ${isSelected ? 'stack-card--selected' : ''}`} onClick={onSelect}>
+      <div class="stack-card__header">
+        <span class="stack-card__name">{stack.name}</span>
+        <span class={`stack-badge stack-badge--${status}`}>{status}</span>
+      </div>
+      <div class="stack-card__meta">
+        <span class="container-count">{running}/{total} running</span>
+        {stack.lastApply && <span class="stack-last-apply">{formatRelative(stack.lastApply)}</span>}
+      </div>
+      {stack.lastError && <div class="stack-error">{stack.lastError}</div>}
+    </div>
+  )
+}
+
+function deriveStackStatus(stack) {
+  if (stack.status === 'error') return 'error'
+  if (stack.status === 'applying') return 'applying'
+  const containers = stack.containers || []
+  if (!containers.length) return 'unknown'
+  if (containers.every(c => c.status === 'running')) return 'running'
+  if (containers.some(c => c.status === 'running')) return 'degraded'
+  return 'stopped'
+}
+```
+
+### Task 4 — Rewrite AppDetail.jsx with container tabs (Logs / Env / Info)
+
+```jsx
+import { useState, useEffect, useRef } from 'preact/hooks'
+import { formatRelative, formatDateTime } from '../utils/time'
+
+export function AppDetail({ stack, onClose }) {
+  const [selectedContainer, setSelectedContainer] = useState(stack.containers?.[0]?.name ?? null)
+  useEffect(() => setSelectedContainer(stack.containers?.[0]?.name ?? null), [stack.name])
+  const container = stack.containers?.find(c => c.name === selectedContainer)
+
+  return (
+    <div class="app-detail">
+      <div class="detail-header">
+        <div class="detail-header__title">
+          <span class="detail-repo">{stack.repoName}</span>
+          <span class="detail-sep">/</span>
+          <h2 class="detail-stack-name">{stack.name}</h2>
+          <span class={`stack-badge stack-badge--${stack.status}`}>{stack.status}</span>
+        </div>
+        <button class="close-btn" onClick={onClose}>✕</button>
+      </div>
+
+      <div class="stack-meta-grid">
+        {stack.lastApply && <MetaItem label="Last deployed" value={formatRelative(stack.lastApply)} />}
+        {stack.stackDir && <MetaItem label="Directory" value={stack.stackDir} mono />}
+        {stack.lastError && <MetaItem label="Error" value={stack.lastError} error />}
+      </div>
+
+      {stack.containers?.length > 0 && (
+        <>
+          <div class="container-tabs">
+            {stack.containers.map(c => (
+              <button key={c.name}
+                class={`container-tab ${c.name === selectedContainer ? 'container-tab--active' : ''}`}
+                onClick={() => setSelectedContainer(c.name)}>
+                <span class={`status-dot status-dot--${c.status}`} />{c.name}
+              </button>
+            ))}
+          </div>
+          {container && <ContainerDetail container={container} />}
+        </>
+      )}
+    </div>
+  )
+}
+
+function MetaItem({ label, value, mono, error }) {
+  return (
+    <div class={`meta-item ${error ? 'meta-item--error' : ''}`}>
+      <span class="meta-label">{label}</span>
+      <span class={`meta-value ${mono ? 'meta-value--mono' : ''}`}>{value}</span>
+    </div>
+  )
+}
+
+function ContainerDetail({ container }) {
+  const [tab, setTab] = useState('logs')
+  return (
+    <div class="container-detail">
+      <div class="info-tabs">
+        {[['logs','📋 Logs'],['env','⚙ Env'],['info','ℹ Info']].map(([t, label]) => (
+          <button key={t} class={`info-tab ${tab === t ? 'info-tab--active' : ''}`} onClick={() => setTab(t)}>{label}</button>
+        ))}
+      </div>
+      {tab === 'logs' && <LogStream container={container.name} />}
+      {tab === 'env' && <EnvVars envs={container.env} />}
+      {tab === 'info' && <ContainerInfo container={container} />}
+    </div>
+  )
+}
+
+function LogStream({ container }) {
+  const [logs, setLogs] = useState([])
+  const endRef = useRef(null)
+  useEffect(() => {
+    setLogs([])
+    const es = new EventSource(`/api/logs/${container}`)
+    es.onmessage = e => setLogs(prev => [...prev, { text: e.data, time: new Date() }].slice(-200))
+    es.onerror = () => es.close()
+    return () => es.close()
+  }, [container])
+  useEffect(() => endRef.current?.scrollIntoView({ behavior: 'smooth' }), [logs])
+  return (
+    <div class="logs-content">
+      {!logs.length && <div class="logs-empty">Waiting for logs…</div>}
+      {logs.map((entry, i) => (
+        <div key={i} class={`log-line ${classifyLog(entry.text)}`}>
+          <span class="log-time">{entry.time.toLocaleTimeString()}</span>
+          <span class="log-text">{entry.text}</span>
+        </div>
+      ))}
+      <div ref={endRef} />
+    </div>
+  )
+}
+
+function EnvVars({ envs }) {
+  if (!envs?.length) return <div class="empty-state">No environment variables.</div>
+  return (
+    <div class="env-list">
+      {envs.map((e, i) => {
+        const eq = e.indexOf('=')
+        const key = eq >= 0 ? e.slice(0, eq) : e
+        const val = eq >= 0 ? e.slice(eq + 1) : ''
+        return (
+          <div key={i} class="env-item">
+            <span class="env-key">{key}</span>
+            <span class={`env-value ${val === '[redacted]' ? 'env-value--redacted' : ''}`}>
+              {val === '[redacted]' ? '••••••' : val}
+            </span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function ContainerInfo({ container }) {
+  const { formatRelative, formatDateTime } = require('../utils/time')
+  return (
+    <div class="container-info">
+      <InfoRow label="Container ID" value={container.id?.slice(0, 12)} mono />
+      <InfoRow label="Image" value={container.image} mono />
+      <InfoRow label="Status" value={container.status} />
+      {container.startedAt && (
+        <InfoRow label="Started" value={`${formatRelative(container.startedAt)} · ${formatDateTime(container.startedAt)}`} />
+      )}
+      {container.ports?.length > 0 && <InfoRow label="Ports" value={container.ports.join(', ')} mono />}
+    </div>
+  )
+}
+
+function InfoRow({ label, value, mono }) {
+  return (
+    <div class="info-row">
+      <span class="info-label">{label}</span>
+      <span class={`info-value ${mono ? 'info-value--mono' : ''}`}>{value || '—'}</span>
+    </div>
+  )
+}
+
+function classifyLog(text) {
+  const l = text.toLowerCase()
+  if (l.includes('error') || l.includes('fatal') || l.includes('panic')) return 'log-error'
+  if (l.includes('warn')) return 'log-warn'
+  if (l.includes('debug')) return 'log-debug'
+  return ''
+}
+```
+
+### Task 5 — Create src/utils/time.js
+
+```js
+export function formatRelative(dateStr) {
+  if (!dateStr) return ''
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const secs = Math.floor(diff / 1000)
+  if (secs < 60) return `${secs}s ago`
+  const mins = Math.floor(secs / 60)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
+
+export function formatDateTime(dateStr) {
+  if (!dateStr) return ''
+  return new Date(dateStr).toLocaleString()
+}
+```
+
+### Task 6 — Modernise CSS (index.css + app.css + component CSS)
+
+Key CSS variables in index.css:
+```css
+:root {
+  --bg-primary: #0d1117;
+  --bg-secondary: #161b22;
+  --bg-tertiary: #21262d;
+  --border-color: #30363d;
+  --text-primary: #e6edf3;
+  --text-secondary: #8b949e;
+  --accent: #00d4ff;
+  --status-running: #3fb950;
+  --status-stopped: #f85149;
+  --status-degraded: #d29922;
+  --status-applying: #58a6ff;
+  --status-error: #f85149;
+  --status-unknown: #8b949e;
+}
+
+@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+.sync-btn--spinning { animation: spin 1s linear infinite; display: inline-block; }
+
+@media (max-width: 768px) {
+  .app-container { flex-direction: column; }
+  .grid-panel { max-height: 45vh; border-bottom: 1px solid var(--border-color); overflow-y: auto; }
+}
+```
+
+app-logo height: 36px (larger, crisp). Write all required classes for every new component.
+
+### Task 7 — Build + commit
+
+```bash
+cd internal/ui && npm install && npm run build && cd ../..
+go build ./...
+git add -A
+git commit -m "feat: modernise dashboard UI
+
+- Restore repo/stack/container hierarchy in AppGrid
+- Add force git sync button per repo (calls POST /api/sync/{repo})
+- Make logo larger (36px, prominent in header)
+- Add container detail tabs: Logs, Env vars, Info
+- Show Docker env vars (sensitive values masked)
+- Show container ports, uptime, image in Info tab
+- Add log timestamps and error/warn colour coding
+- Add 5s auto-refresh with error banner + Retry
+- Fix HTML title to 'stackd'
+- Add responsive mobile layout
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
 
 ## Acceptance Criteria
 
-- Dashboard shows stacks (not containers) as primary entities in the grid
-- Clicking a stack opens the detail panel with container tabs
-- Each container tab streams that container's logs via SSE
-- Repo sync status visible with per-repo sync trigger
-- Dark mode toggle works and persists across page loads
-- `npm run build` succeeds with no errors
-- `go build ./...` succeeds with embedded new frontend
+- [ ] HTML title is "stackd"
+- [ ] Logo visible at 36px in header
+- [ ] Repo → Stack → Container hierarchy in sidebar
+- [ ] Each repo shows: name, short SHA, last sync time, ↻ force sync button
+- [ ] Force sync calls POST /api/sync/{repo} with spin animation
+- [ ] Clicking a stack opens AppDetail
+- [ ] AppDetail has container tabs, each with Logs / Env / Info sub-tabs
+- [ ] Env tab shows env vars; sensitive keys show ••••••
+- [ ] Info tab shows ID, image, status, uptime, ports
+- [ ] Logs show timestamps + error/warn colours
+- [ ] Status auto-refreshes every 5 seconds
+- [ ] Error banner with Retry button when API unreachable
+- [ ] npm run build passes
+- [ ] go build ./... passes

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log"
@@ -40,7 +41,7 @@ func New(store *state.Store, dockerClient *docker.Client, syncTrigger chan<- str
 }
 
 // Start binds and serves. Blocks until the server exits.
-func (s *Server) Start() {
+func (s *Server) Start(ctx context.Context) {
 	srv := &http.Server{
 		Addr:         s.addr,
 		Handler:      s.mux,
@@ -48,8 +49,18 @@ func (s *Server) Start() {
 		WriteTimeout: 0, // 0 = no timeout; needed for SSE streams
 		IdleTimeout:  60 * time.Second,
 	}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("Dashboard server shutdown error: %v", err)
+		}
+	}()
+
 	log.Printf("Dashboard listening on %s", s.addr)
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Printf("Dashboard server error: %v", err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -6,9 +6,12 @@ import (
 "log"
 "os"
 "os/exec"
+"os/signal"
 "path/filepath"
 "strconv"
 "strings"
+"sync"
+"syscall"
 "time"
 
 "gopkg.in/yaml.v3"
@@ -22,9 +25,85 @@ import (
 type AppConfig struct {
 PullOnly            bool
 SyncIntervalSeconds int
+SyncInterval        time.Duration
 GitUserName         string
 GitUserEmail        string
 ConfigFile          string // path to optional stackd.yaml; empty = not used
+}
+
+// syncBackoff tracks retry state for a single repo.
+type syncBackoff struct {
+mu          sync.Mutex
+failures    int
+nextAllowed time.Time
+suspended   bool // true after maxFailures consecutive failures
+}
+
+const maxSyncFailures = 10
+
+var repoBackoffs sync.Map // key: repo name (string), value: *syncBackoff
+var repoLocks sync.Map   // key: repo name (string), value: *sync.Mutex
+
+func getBackoff(repoName string) *syncBackoff {
+v, _ := repoBackoffs.LoadOrStore(repoName, &syncBackoff{})
+return v.(*syncBackoff)
+}
+
+// recordSyncSuccess resets the backoff for a repo.
+func recordSyncSuccess(repoName string) {
+b := getBackoff(repoName)
+b.mu.Lock()
+defer b.mu.Unlock()
+b.failures = 0
+b.nextAllowed = time.Time{}
+b.suspended = false
+}
+
+// recordSyncFailure increments failure count and sets next allowed time.
+// Returns true if the repo is now suspended (max failures reached).
+func recordSyncFailure(repoName string, baseInterval time.Duration) bool {
+b := getBackoff(repoName)
+b.mu.Lock()
+defer b.mu.Unlock()
+b.failures++
+if b.failures >= maxSyncFailures {
+b.suspended = true
+log.Printf("Repo %q suspended after %d consecutive failures; trigger manual sync to resume", repoName, b.failures)
+return true
+}
+multiplier := time.Duration(1 << b.failures) // 2, 4, 8, 16...
+backoff := multiplier * baseInterval
+maxBackoff := 8 * baseInterval
+if backoff > maxBackoff {
+backoff = maxBackoff
+}
+b.nextAllowed = time.Now().Add(backoff)
+log.Printf("Repo %q sync backoff: next attempt in %s (failure %d/%d)", repoName, backoff, b.failures, maxSyncFailures)
+return false
+}
+
+// shouldSkipSync returns true if the repo is in backoff or suspended.
+func shouldSkipSync(repoName string) bool {
+b := getBackoff(repoName)
+b.mu.Lock()
+defer b.mu.Unlock()
+if b.suspended {
+return true
+}
+if !b.nextAllowed.IsZero() && time.Now().Before(b.nextAllowed) {
+return true
+}
+return false
+}
+
+// resetBackoff resets backoff for a repo (called on manual sync trigger).
+func resetBackoff(repoName string) {
+b := getBackoff(repoName)
+b.mu.Lock()
+defer b.mu.Unlock()
+b.failures = 0
+b.nextAllowed = time.Time{}
+b.suspended = false
 }
 
 // RepoConfig holds per-repository configuration, derived from env vars or stackd.yaml.
@@ -201,17 +280,30 @@ return exec.CommandContext(ctx, "docker", "compose", "up", "-d")
 }
 
 // refreshContainers updates container details for all stacks whose StackDir is
-// known. Safe to call with a nil dockerClient (no-op).
-func refreshContainers(ctx context.Context, store *state.Store, dockerClient *docker.Client) {
-if dockerClient == nil {
+// known. Safe to call with a nil dockerClientPtr (no-op). Attempts reconnection
+// if *dockerClientPtr is nil.
+func refreshContainers(ctx context.Context, store *state.Store, dockerClientPtr **docker.Client) {
+if dockerClientPtr == nil {
 return
+}
+if *dockerClientPtr == nil {
+reconnCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+defer cancel()
+if c, err := docker.New(); err == nil {
+log.Printf("Docker client reconnected successfully")
+*dockerClientPtr = c
+} else {
+log.Printf("Docker reconnection failed: %v", err)
+_ = reconnCtx
+return
+}
 }
 for _, st := range store.GetAllStacks() {
 if st.StackDir == "" {
 continue
 }
 refreshCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-ctrs, err := dockerClient.ListStackContainerDetails(refreshCtx, st.StackDir)
+ctrs, err := (*dockerClientPtr).ListStackContainerDetails(refreshCtx, st.StackDir)
 cancel()
 if err != nil {
 log.Printf("refreshContainers %s/%s: %v", st.RepoName, st.Name, err)
@@ -317,6 +409,7 @@ syncIntervalSeconds = v
 return AppConfig{
 PullOnly:            pullOnly,
 SyncIntervalSeconds: syncIntervalSeconds,
+SyncInterval:        time.Duration(syncIntervalSeconds) * time.Second,
 GitUserName:         gitUserName,
 GitUserEmail:        gitUserEmail,
 ConfigFile:          os.Getenv("STACKD_CONFIG"),
@@ -500,7 +593,14 @@ existing.Status = state.StatusError
 existing.LastError = msg
 store.UpdateRepo(existing)
 }
+recordSyncFailure(repoName, appCfg.SyncInterval)
 }
+
+// Ensure only one sync runs per repo at a time.
+lockVal, _ := repoLocks.LoadOrStore(cfg.Name, &sync.Mutex{})
+repoMu := lockVal.(*sync.Mutex)
+repoMu.Lock()
+defer repoMu.Unlock()
 
 // Mark the directory as safe for Git using --system instead of --global
 safeCtx, safeCancel := context.WithTimeout(ctx, 10*time.Second)
@@ -573,6 +673,7 @@ LastSHA:  currentSHA,
 Status:   state.StatusOK,
 })
 }
+recordSyncSuccess(repoName)
 return
 }
 
@@ -610,6 +711,7 @@ LastSHA:  currentSHA,
 Status:   state.StatusOK,
 })
 }
+recordSyncSuccess(repoName)
 return
 }
 
@@ -639,6 +741,7 @@ LastSHA:  currentSHA,
 Status:   state.StatusOK,
 })
 }
+recordSyncSuccess(repoName)
 }
 
 func main() {
@@ -667,13 +770,17 @@ Env:     os.Getenv("INFISICAL_ENV"),
 })
 
 // --- Docker client (used for container details and log streaming) ---
-dockerClient, err := docker.New()
-if err != nil {
+var dockerClient *docker.Client
+if c, err := docker.New(); err == nil {
+dockerClient = c
+} else {
 log.Printf("Warning: Docker client unavailable (%v) — container details and log streaming disabled", err)
-dockerClient = nil
 }
 
-ctx := context.Background()
+ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+defer stop()
+
+var wg sync.WaitGroup
 
 // --- Startup stack scan ---
 // Populate the state store with known stacks at startup so the dashboard
@@ -682,7 +789,7 @@ if repoCfgs, err := loadRepoConfigs(appCfg); err == nil {
 for _, cfg := range repoCfgs {
 runStacksSync(ctx, cfg, store, dockerClient)
 }
-refreshContainers(ctx, store, dockerClient)
+refreshContainers(ctx, store, &dockerClient)
 }
 
 // --- Dashboard server ---
@@ -700,12 +807,31 @@ log.Printf("Invalid DASHBOARD_PORT value %q, using default 8080", portStr)
 }
 
 srv := server.New(store, dockerClient, syncTrigger, dashPort)
-go srv.Start()
+go srv.Start(ctx)
 }
 
 syncInterval := time.Duration(appCfg.SyncIntervalSeconds) * time.Second
 ticker := time.NewTicker(syncInterval)
 defer ticker.Stop()
+
+doSyncRound := func(cfgs []RepoConfig) {
+wg.Add(1)
+go func() {
+defer wg.Done()
+for _, cfg := range cfgs {
+if ctx.Err() != nil {
+return // shutdown in progress, stop starting new syncs
+}
+if shouldSkipSync(cfg.Name) {
+log.Printf("Skipping sync for %q (backoff)", cfg.Name)
+continue
+}
+syncRepo(ctx, cfg, appCfg, store, dockerClient)
+}
+refreshContainers(ctx, store, &dockerClient)
+}()
+wg.Wait() // keep sequential behaviour; WaitGroup lets shutdown detect completion
+}
 
 for {
 repoCfgs, err := loadRepoConfigs(appCfg)
@@ -713,15 +839,23 @@ if err != nil {
 log.Fatalf("Failed to get mounted volumes: %v", err)
 }
 
-for _, cfg := range repoCfgs {
-syncRepo(ctx, cfg, appCfg, store, dockerClient)
-}
-
-// Refresh container state for all known stacks (startup + every tick).
-refreshContainers(ctx, store, dockerClient)
+doSyncRound(repoCfgs)
 
 // Wait for the next tick or a manual sync trigger.
 select {
+case <-ctx.Done():
+log.Printf("Shutdown signal received, waiting for in-flight operations to complete...")
+ticker.Stop()
+waitDone := make(chan struct{})
+go func() { wg.Wait(); close(waitDone) }()
+select {
+case <-waitDone:
+log.Printf("All operations completed, shutting down cleanly")
+case <-time.After(30 * time.Second):
+log.Printf("Shutdown timeout reached, forcing exit")
+}
+return
+
 case <-ticker.C:
 // regular interval — loop back to sync all repos
 
@@ -736,13 +870,14 @@ break drainLoop
 }
 }
 log.Printf("Manual sync triggered for %q", repoName)
+resetBackoff(repoName) // manual sync always resets backoff
 for _, cfg := range repoCfgs {
 if cfg.Name == repoName {
 syncRepo(ctx, cfg, appCfg, store, dockerClient)
 break
 }
 }
-refreshContainers(ctx, store, dockerClient)
+refreshContainers(ctx, store, &dockerClient)
 ticker.Reset(syncInterval)
 }
 }


### PR DESCRIPTION
## What's in this PR

This consolidates all Phase 1 and Phase 2 delivery work from three stacked branches:

### Phase 1 — Foundation

**Code Quality** (`refactor/code-quality-fixes`):
- Renamed Go module from `simpleGithubSync` → `stackd`
- Removed both `goto` statements — extracted `buildComposeCmd()` helper, replaced drain loop with labelled `break`
- Added `context.Context` + timeouts to all `exec.Command` calls (git: 10–120s, compose/infisical: 300s, keyscan: 30s)
- Updated all import paths

**Config Refactor** (`refactor/config-refactor`):
- Added `RepoConfig` and `AppConfig` structs
- Per-repo `BRANCH_<REPO>` and `REMOTE_<REPO>` env vars (fixes hardcoded `origin main` bug — CI was targeting `master` while code pulled `main`)
- `BRANCH_DEFAULT` fallback
- Optional `stackd.yaml` config file (`STACKD_CONFIG` env var)
- Threaded config through `syncRepo`, `runStacksSync`, `runPostSyncCommand`
- README updated

### Phase 2 — Core Reliability

**Resilience** (`refactor/resilience`):
- **Graceful shutdown**: `signal.NotifyContext` for SIGINT/SIGTERM; 30s drain window for in-flight syncs; HTTP server calls `srv.Shutdown()` on cancel
- **Exponential backoff**: per-repo `syncBackoff` state, `2^n × interval` delay capped at 8×, suspended after 10 consecutive failures, resumes on manual sync
- **Docker reconnection**: `refreshContainers` auto-reconnects if Docker client is nil
- **Per-repo mutex**: `sync.Map` of `*sync.Mutex` prevents concurrent scheduled + manual sync races on same repo directory

## Checklist
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] No `goto` statements
- [x] No hardcoded `origin`/`main` in git commands
- [x] All branches pushed to origin