### PR TITLE
feat: Phase 4 — modernised dashboard UI

### DIFF
--- a/.github/agents/documentation.agent.md
+++ b/.github/agents/documentation.agent.md
@@ -1,0 +1,272 @@
+---
+name: "Documentation Specialist"
+description: "Creates and maintains a docs/ folder with comprehensive, well-structured documentation for stackd. Simplifies the main README to a clean quick-start landing page with links into the docs."
+tools: ["search", "read_file", "edit_file", "run_terminal_command", "list_directory"]
+model: "claude-sonnet-4.6"
+---
+
+# stackd Documentation Specialist Agent
+
+You are a technical documentation writer for **stackd**. Your job is to:
+1. Create a `docs/` folder with thorough, well-structured reference documentation
+2. Simplify `README.md` to a clean landing page (quick-start + links)
+3. Keep both in sync as the codebase evolves
+
+Always read the current state of `README.md`, `main.go`, `internal/server/server.go`,
+and `internal/state/state.go` before writing — derive facts from code, not assumptions.
+
+---
+
+## Docs Folder Structure to Create
+
+```
+docs/
+├── configuration.md      # All env vars, stackd.yaml schema, per-repo overrides
+├── installation.md       # Docker Compose setup, volume mounts, first run
+├── ssh.md                # SSH key setup, known_hosts, troubleshooting
+├── infisical.md          # Infisical integration, per-stack toml, global token
+├── security.md           # Dashboard auth, rate limiting, secrets masking
+├── observability.md      # Logging (slog), /healthz, /readyz, /metrics
+├── api.md                # Full HTTP API reference with request/response examples
+├── multi-repo.md         # Multi-repo setup patterns and examples
+├── post-sync-hooks.md    # POST_SYNC_<REPO> hooks with examples
+└── architecture.md       # How stackd works internally (sync loop, state, Docker)
+```
+
+---
+
+## Target README.md Structure (After Simplification)
+
+The README should be a **landing page**, not a manual. Target ~60 lines (down from ~200+).
+
+```markdown
+<div align="center">
+  <img src="assets/logo.svg" alt="stackd" width="400"/>
+  ...badges...
+</div>
+
+---
+
+One-sentence description. "Think of it as ArgoCD for Docker Compose."
+
+## Features
+- 5-6 bullet points max (headlines only, no detail)
+
+## Quick Start
+- Minimal docker-compose.yml example (single repo, pull-only)
+- One command to start
+- "Open http://localhost:8080"
+
+## Documentation
+Links to every docs/ file with one-line description each.
+
+## License
+MIT — see LICENSE.
+```
+
+Everything else (full env var table, SSH setup, Infisical config, security, API
+reference, etc.) moves to `docs/`.
+
+---
+
+## Each Doc File — Content Requirements
+
+### `docs/configuration.md`
+
+- Intro: "stackd is configured entirely via environment variables, with an optional
+  `stackd.yaml` config file for complex setups."
+- Full env var reference table (all variables from README, plus any found in main.go
+  not yet documented) — grouped by category:
+  - Git & Sync
+  - Stacks
+  - Dashboard
+  - Security
+  - Infisical
+  - Logging & Observability
+- `stackd.yaml` full schema with annotated example
+- Precedence rules: env vars > yaml file > defaults
+- Per-repo overrides: `BRANCH_<REPO>`, `REMOTE_<REPO>`, `STACKS_DIR_<REPO>`,
+  `POST_SYNC_<REPO>`
+
+### `docs/installation.md`
+
+- Prerequisites (Docker, Docker Compose, SSH key, Git repo)
+- Minimal single-repo setup (docker-compose.yml)
+- Multi-repo setup (link to `multi-repo.md`)
+- Volume mount reference table (what to mount where and why)
+- First-run checklist
+- Upgrading (pull latest image tag)
+
+### `docs/ssh.md`
+
+- Why SSH is needed (private repos)
+- Supported key types (RSA, Ed25519)
+- Volume mount example
+- `SSH_KEY_PATH` configuration
+- How stackd handles `known_hosts` (auto-scans `github.com`)
+- Adding other Git hosts (e.g., GitLab, self-hosted Gitea)
+- Troubleshooting: permission errors, host key verification failed
+
+### `docs/infisical.md`
+
+- What Infisical integration does
+- Enabling with `INFISICAL_ENABLED=true`
+- Auth priority:
+  1. Per-stack `infisical.toml`
+  2. Global `INFISICAL_TOKEN` + `INFISICAL_ENV`
+  3. Fallback (warning, no secrets injected)
+- Global token setup (env var example)
+- Per-stack toml: full `infisical.toml` schema + example
+- Self-hosted Infisical (`INFISICAL_URL`)
+- Directory layout example (which stacks use toml vs. global)
+- Secrets in logs: stackd masks token values — never logged
+
+### `docs/security.md`
+
+- Dashboard authentication: `DASHBOARD_TOKEN` bearer token
+  - How to set it
+  - Public endpoints (always accessible without auth)
+  - How the UI handles auth (401 → prompt)
+- Rate limiting: `SYNC_RATE_LIMIT_SECONDS`
+- Security response headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy)
+- Secrets masking: which patterns are masked in logs
+- Recommendations for production:
+  - Always set `DASHBOARD_TOKEN` in production
+  - Use `PULL_ONLY=true` if you don't need stackd to push commits
+  - Run behind a reverse proxy with TLS
+
+### `docs/observability.md`
+
+- Logging:
+  - Default: JSON to stdout (`LOG_FORMAT=json`)
+  - Human-readable: `LOG_FORMAT=text`
+  - Log levels: `LOG_LEVEL=debug|info|warn|error`
+  - Structured fields: `repo`, `stack`, `err`, `sha`
+  - `docker logs -f stackd` example
+- Health probes:
+  - `GET /healthz` — liveness (always 200 while process is alive)
+  - `GET /readyz` — readiness (200 when Docker + at least one sync done)
+  - Docker Compose healthcheck example
+  - Kubernetes probe example
+- Prometheus metrics (`GET /metrics`):
+  - Full metric reference table:
+    | Metric | Type | Labels | Description |
+    |---|---|---|---|
+    | `stackd_sync_total` | Counter | `repo`, `status` | Total sync attempts |
+    | `stackd_sync_duration_seconds_sum/count` | Histogram | `repo` | Sync duration |
+    | `stackd_stack_apply_total` | Counter | `stack`, `status` | Apply attempts |
+    | `stackd_containers_running` | Gauge | `stack` | Running containers |
+    | `stackd_last_sync_timestamp` | Gauge | `repo` | Unix timestamp of last sync |
+  - Prometheus scrape config example
+  - Grafana dashboard hints
+
+### `docs/api.md`
+
+Full HTTP API reference. For each endpoint:
+- Method + path
+- Auth required? (yes/no)
+- Description
+- Request example (curl)
+- Response schema + example
+
+Endpoints to document:
+- `GET /api/status`
+- `POST /api/sync/{repo}`
+- `GET /api/logs/{container}`
+- `GET /healthz`
+- `GET /readyz`
+- `GET /metrics`
+
+Include the full `/api/status` JSON schema derived from `state.go` types.
+
+### `docs/multi-repo.md`
+
+- Concept: each mounted directory under `REPOS_DIR` is a repo
+- Volume mount pattern
+- `STACKS_DIR_<REPO>` per repo
+- Per-repo branch/remote overrides
+- Full multi-repo docker-compose.yml example (3 repos)
+- Using `stackd.yaml` for multi-repo config instead of env vars
+- Independent sync intervals (not currently supported — note as limitation)
+
+### `docs/post-sync-hooks.md`
+
+- What post-sync hooks are and when they run (after pull, before stack apply)
+- `POST_SYNC_<REPO>` env var
+- Examples:
+  - Run an extra compose file
+  - Send a webhook notification
+  - Restart a specific container
+  - Run a migration script
+- Hook execution: runs with `sh -c`, 5 min timeout, output logged
+- Error handling: failure is logged but does not block stack apply
+
+### `docs/architecture.md`
+
+High-level explanation of how stackd works internally. Include a diagram in ASCII
+or Mermaid format. Cover:
+
+- **Startup sequence**: SSH setup → state store → Docker client → startup stack scan
+  → HTTP server → main loop
+- **Main loop**: ticker + manual sync trigger channel; sequential repo syncs
+- **Sync flow**:
+  ```
+  syncRepo(cfg)
+    ├─ git fetch {remote}
+    ├─ compare local SHA vs remote SHA
+    ├─ [if changed] git pull {remote} {branch}
+    ├─ runPostSyncCommand(cfg)
+    └─ runStacksSync(cfg)
+         └─ applyStack(stackPath)
+              └─ docker compose up -d
+                 (or infisical run -- docker compose up -d)
+  ```
+- **State store**: in-memory, thread-safe (`sync.RWMutex`), rebuilt on restart
+- **Dashboard server**: embedded Preact SPA + REST API + SSE log streaming
+- **Resilience**: exponential backoff, per-repo mutex, SIGTERM drain, Docker reconnect
+- **Configuration precedence**: env vars > stackd.yaml > defaults
+
+---
+
+## Writing Guidelines
+
+- **Tone**: clear, direct, technical. Home lab users + small DevOps teams audience.
+- **Code blocks**: always include a language hint (```yaml, ```bash, ```go, etc.)
+- **Examples**: every doc should have at least one copy-paste ready example
+- **Links**: cross-link between docs where relevant (e.g., security.md links to api.md
+  for public endpoint list)
+- **No fluff**: no "Introduction" sections that repeat what the heading says. Start with
+  the useful content immediately.
+- **Admonitions**: use `> **Note:**`, `> **Warning:**` for important callouts
+
+---
+
+## Execution Steps
+
+1. Read current `README.md`, `main.go`, `internal/state/state.go`,
+   `internal/server/server.go` to gather all facts
+2. Create `docs/` directory
+3. Write each doc file in order (configuration first — others reference it)
+4. Rewrite `README.md` to be the clean landing page
+5. Verify all links in README point to valid files in `docs/`
+6. Commit:
+
+```bash
+git add docs/ README.md
+git commit -m "docs: add docs/ folder and simplify README
+
+- Create docs/ with 10 reference documents
+- docs/configuration.md — full env var reference and stackd.yaml schema
+- docs/installation.md — setup guide and volume mount reference
+- docs/ssh.md — SSH key setup and troubleshooting
+- docs/infisical.md — secrets integration guide
+- docs/security.md — auth, rate limiting, production hardening
+- docs/observability.md — logging, health probes, Prometheus metrics
+- docs/api.md — full HTTP API reference
+- docs/multi-repo.md — multi-repo setup patterns
+- docs/post-sync-hooks.md — post-sync hook examples
+- docs/architecture.md — internal architecture and sync flow
+- Simplify README to quick-start landing page with links to docs
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/docker/go-connections/nat"
 )
 
 // ContainerDetail holds runtime information about a single container.
@@ -20,6 +21,8 @@ type ContainerDetail struct {
 	Image     string    `json:"image"`
 	Status    string    `json:"status"`
 	StartedAt time.Time `json:"startedAt"`
+	Env       []string  `json:"env"`   // env vars with sensitive values masked
+	Ports     []string  `json:"ports"` // ["8080:80/tcp", ...]
 }
 
 type ContainerStatus string
@@ -125,12 +128,60 @@ func (c *Client) ListStackContainerDetails(ctx context.Context, stackDir string)
 			d.ID = d.ID[:12]
 		}
 		info, err := c.cli.ContainerInspect(ctx, ct.ID)
-		if err == nil && info.State != nil {
-			d.StartedAt, _ = time.Parse(time.RFC3339Nano, info.State.StartedAt)
+		if err == nil {
+			if info.State != nil {
+				d.StartedAt, _ = time.Parse(time.RFC3339Nano, info.State.StartedAt)
+			}
+			if info.Config != nil {
+				d.Env = maskEnvVars(info.Config.Env)
+			}
+			if info.NetworkSettings != nil {
+				d.Ports = formatPorts(info.NetworkSettings.Ports)
+			}
 		}
 		details = append(details, d)
 	}
 	return details, nil
+}
+
+func maskEnvVars(envs []string) []string {
+	sensitive := []string{"TOKEN", "SECRET", "KEY", "PASSWORD", "PASS", "CREDENTIAL"}
+	result := make([]string, 0, len(envs))
+	for _, e := range envs {
+		eq := strings.Index(e, "=")
+		if eq >= 0 {
+			upper := strings.ToUpper(e[:eq])
+			masked := false
+			for _, s := range sensitive {
+				if strings.Contains(upper, s) {
+					result = append(result, e[:eq]+"=[redacted]")
+					masked = true
+					break
+				}
+			}
+			if !masked {
+				result = append(result, e)
+			}
+		} else {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+func formatPorts(portMap nat.PortMap) []string {
+	var ports []string
+	for port, bindings := range portMap {
+		for _, b := range bindings {
+			if b.HostPort != "" {
+				ports = append(ports, b.HostPort+":"+port.Port()+"/"+port.Proto())
+			}
+		}
+		if len(bindings) == 0 {
+			ports = append(ports, port.Port()+"/"+port.Proto())
+		}
+	}
+	return ports
 }
 
 // ListStackContainers returns the names of all containers belonging to the

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -36,6 +36,8 @@ type ContainerDetail struct {
 	Image     string    `json:"image"`
 	Status    string    `json:"status"`
 	StartedAt time.Time `json:"startedAt"`
+	Env       []string  `json:"env"`   // env vars with sensitive values masked
+	Ports     []string  `json:"ports"` // ["8080:80/tcp", ...]
 }
 
 type StackState struct {

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -3,7 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SimpleGithubSync</title>
+    <title>stackd</title>
+    <meta name="description" content="GitOps dashboard for Docker Compose deployments">
+    <meta name="theme-color" content="#0d1117">
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
   </head>
   <body>

--- a/internal/ui/src/app.css
+++ b/internal/ui/src/app.css
@@ -1,57 +1,100 @@
-/* Dark theme */
-:root {
-  --bg-primary: #1a1a1a;
-  --bg-secondary: #2d2d2d;
-  --text-primary: #e0e0e0;
-  --text-secondary: #b0b0b0;
-  --border-color: #404040;
-  --accent: #00d4ff;
-  --accent-hover: #00a8cc;
-}
-
-body {
-  background-color: var(--bg-primary);
-  color: var(--text-primary);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  margin: 0;
-  padding: 0;
-}
-
 .app-shell {
   display: flex;
   flex-direction: column;
   height: 100vh;
+  background: var(--bg-primary);
 }
 
+/* Header */
 .app-header {
-  flex-shrink: 0;
-  padding: 12px 20px;
-  background: #0d1117;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px;
+  height: 56px;
+  background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.app-header__brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .app-logo {
-  height: 40px;
+  height: 32px;
   width: auto;
-  display: block;
 }
 
+.app-header__meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.infisical-badge {
+  font-size: 12px;
+  color: var(--accent);
+  background: var(--accent-dim);
+  border: 1px solid rgba(0, 212, 255, 0.2);
+  padding: 3px 10px;
+  border-radius: 12px;
+}
+
+/* Error banner */
+.error-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 24px;
+  background: rgba(248, 81, 73, 0.1);
+  border-bottom: 1px solid rgba(248, 81, 73, 0.3);
+  color: #f85149;
+  font-size: 13px;
+}
+
+.error-banner button {
+  background: rgba(248, 81, 73, 0.15);
+  border: 1px solid rgba(248, 81, 73, 0.4);
+  color: #f85149;
+  padding: 4px 12px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.error-banner button:hover {
+  background: rgba(248, 81, 73, 0.25);
+}
+
+/* Main layout */
 .app-container {
   display: flex;
   flex: 1;
-  min-height: 0;
-  gap: 1px;
-  background: var(--border-color);
+  overflow: hidden;
 }
 
 .grid-panel {
-  flex: 0 0 35%;
+  width: 340px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border-color);
   overflow-y: auto;
-  background: var(--bg-primary);
+  background: var(--bg-secondary);
 }
 
 .detail-panel {
   flex: 1;
-  overflow-y: auto;
-  background: var(--bg-primary);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  animation: fadeIn 0.15s ease-out;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .app-container { flex-direction: column; }
+  .grid-panel { width: 100%; max-height: 45vh; border-right: none; border-bottom: 1px solid var(--border-color); }
+  .detail-panel { flex: 1; }
 }

--- a/internal/ui/src/app.jsx
+++ b/internal/ui/src/app.jsx
@@ -4,43 +4,79 @@ import { AppDetail } from './components/AppDetail'
 import './app.css'
 
 export function App() {
-  const [selectedApp, setSelectedApp] = useState(null)
-  const [apps, setApps] = useState([])
+  const [repos, setRepos] = useState([])
+  const [infisical, setInfisical] = useState(null)
+  const [selectedStack, setSelectedStack] = useState(null)
+  const [error, setError] = useState(null)
+  const [syncingRepos, setSyncingRepos] = useState(new Set())
 
-  useEffect(() => {
+  const fetchStatus = () => {
     fetch('/api/status')
       .then(r => r.json())
       .then(data => {
-        const containers = []
-        for (const repo of data.repos || []) {
-          for (const stack of repo.stacks || []) {
-            for (const c of stack.containers || []) {
-              containers.push({
-                id: c.name,
-                name: c.name,
-                status: c.status,
-                version: c.image,
-              })
-            }
-          }
-        }
-        setApps(containers)
+        setRepos(data.repos || [])
+        setInfisical(data.infisical)
+        setError(null)
       })
-      .catch(() => setApps([]))
+      .catch(err => setError(err.message))
+  }
+
+  useEffect(() => {
+    fetchStatus()
+    const interval = setInterval(fetchStatus, 5000)
+    return () => clearInterval(interval)
   }, [])
+
+  const handleForceSync = (repoName) => {
+    setSyncingRepos(prev => new Set([...prev, repoName]))
+    fetch(`/api/sync/${repoName}`, { method: 'POST' })
+      .finally(() => {
+        setTimeout(() => {
+          setSyncingRepos(prev => {
+            const s = new Set(prev)
+            s.delete(repoName)
+            return s
+          })
+        }, 3000)
+      })
+  }
 
   return (
     <div class="app-shell">
       <header class="app-header">
-        <img src="/logo.svg" alt="stackd" class="app-logo" />
+        <div class="app-header__brand">
+          <img src="/logo.svg" alt="stackd" class="app-logo" />
+        </div>
+        <div class="app-header__meta">
+          {infisical?.enabled && (
+            <span class="infisical-badge">🔒 Infisical · {infisical.env}</span>
+          )}
+        </div>
       </header>
+
+      {error && (
+        <div class="error-banner">
+          <span>⚠ Could not reach API: {error}</span>
+          <button onClick={fetchStatus}>Retry</button>
+        </div>
+      )}
+
       <div class="app-container">
         <div class="grid-panel">
-          <AppGrid apps={apps} onSelect={setSelectedApp} />
+          <AppGrid
+            repos={repos}
+            selectedStack={selectedStack}
+            syncingRepos={syncingRepos}
+            onSelectStack={setSelectedStack}
+            onForceSync={handleForceSync}
+          />
         </div>
-        {selectedApp && (
+        {selectedStack && (
           <div class="detail-panel">
-            <AppDetail app={selectedApp} onClose={() => setSelectedApp(null)} />
+            <AppDetail
+              stack={selectedStack}
+              onClose={() => setSelectedStack(null)}
+            />
           </div>
         )}
       </div>

--- a/internal/ui/src/components/AppDetail.css
+++ b/internal/ui/src/components/AppDetail.css
@@ -2,148 +2,300 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 20px;
+  background: var(--bg-primary);
 }
 
+/* Header */
 .detail-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: 20px;
-  padding-bottom: 15px;
+  justify-content: space-between;
+  padding: 14px 20px;
   border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  flex-shrink: 0;
 }
 
-.detail-header h1 {
+.detail-header__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.detail-repo {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.detail-sep {
+  color: var(--border-color);
+  font-size: 16px;
+}
+
+.detail-stack-name {
   margin: 0;
-  font-size: 24px;
+  font-size: 15px;
+  font-weight: 600;
   color: var(--text-primary);
 }
 
 .close-btn {
   background: none;
-  border: none;
+  border: 1px solid var(--border-color);
   color: var(--text-secondary);
-  font-size: 24px;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  padding: 0;
-  width: 32px;
-  height: 32px;
+  font-size: 14px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 4px;
-  transition: all 0.2s;
+  flex-shrink: 0;
+  transition: all 0.15s;
 }
 
 .close-btn:hover {
-  background: var(--bg-secondary);
-  color: var(--text-primary);
+  border-color: #f85149;
+  color: #f85149;
 }
 
-.detail-info {
-  margin-bottom: 20px;
-  padding: 15px;
-  background: var(--bg-secondary);
-  border-radius: 4px;
-}
-
-.info-row {
+/* Stack metadata grid */
+.stack-meta-grid {
   display: flex;
-  gap: 12px;
-  margin-bottom: 8px;
-  font-size: 14px;
+  flex-wrap: wrap;
+  gap: 0;
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
 }
 
-.info-row:last-child {
-  margin-bottom: 0;
-}
-
-.label {
-  color: var(--text-secondary);
-  font-weight: 500;
-  min-width: 80px;
-}
-
-.status-badge {
-  padding: 4px 8px;
-  border-radius: 3px;
-  font-weight: 600;
-  font-size: 12px;
-}
-
-.status-badge.status-running {
-  background: rgba(0, 212, 255, 0.1);
-  color: var(--accent);
-}
-
-.status-badge.status-stopped {
-  background: rgba(255, 100, 100, 0.1);
-  color: #ff6464;
-}
-
-.logs-container {
-  flex: 1;
+.meta-item {
   display: flex;
   flex-direction: column;
+  padding: 10px 20px;
+  border-right: 1px solid var(--border-color);
+  min-width: 0;
+}
+
+.meta-item--error { background: rgba(248, 81, 73, 0.05); }
+
+.meta-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+  margin-bottom: 2px;
+}
+
+.meta-value {
+  font-size: 13px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 300px;
+}
+
+.meta-value--mono {
+  font-family: monospace;
+  font-size: 12px;
+  color: var(--text-mono);
+}
+
+.meta-item--error .meta-value { color: #f85149; }
+
+/* Container tabs */
+.container-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border-color);
   background: var(--bg-secondary);
-  border-radius: 4px;
+  overflow-x: auto;
+  flex-shrink: 0;
+}
+
+.container-tab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  background: none;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s;
+}
+
+.container-tab:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+.container-tab--active { background: var(--bg-tertiary); border-color: var(--border-color); color: var(--text-primary); }
+
+.status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.status-dot--running { background: var(--status-running); }
+.status-dot--stopped, .status-dot--exited { background: var(--status-stopped); }
+.status-dot--restarting { background: var(--status-degraded); }
+
+/* Container detail */
+.container-detail {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
   overflow: hidden;
 }
 
-.logs-container h3 {
-  margin: 0;
-  padding: 12px 15px;
+/* Info tabs (Logs / Env / Info) */
+.info-tabs {
+  display: flex;
+  gap: 1px;
+  padding: 8px 16px 0;
   border-bottom: 1px solid var(--border-color);
-  font-size: 14px;
-  color: var(--text-primary);
+  background: var(--bg-secondary);
+  flex-shrink: 0;
 }
 
+.info-tab {
+  padding: 6px 14px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-bottom: -1px;
+}
+
+.info-tab:hover { color: var(--text-primary); }
+.info-tab--active { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* Logs */
 .logs-content {
   flex: 1;
   overflow-y: auto;
-  font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+  padding: 8px;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
   font-size: 12px;
-  padding: 12px;
-  line-height: 1.4;
+  line-height: 1.6;
+  background: #0a0c10;
+}
+
+.logs-empty {
+  color: var(--text-secondary);
+  padding: 20px;
+  text-align: center;
 }
 
 .log-line {
   display: flex;
-  gap: 12px;
-  margin-bottom: 4px;
-  color: var(--text-secondary);
+  gap: 10px;
+  padding: 1px 4px;
+  border-radius: 2px;
 }
+
+.log-line:hover { background: rgba(255,255,255,0.03); }
 
 .log-time {
-  color: var(--text-secondary);
-  min-width: 120px;
+  color: #484f58;
   flex-shrink: 0;
+  font-size: 11px;
+  padding-top: 1px;
 }
 
-.log-level {
-  min-width: 60px;
+.log-text { color: #adbac7; word-break: break-all; }
+.log-error .log-text { color: #ff7b72; }
+.log-warn .log-text { color: #e3b341; }
+.log-debug .log-text { color: #79c0ff; }
+
+/* Env vars */
+.env-list {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.env-item {
+  display: flex;
+  gap: 0;
+  font-family: monospace;
+  font-size: 12px;
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  overflow: hidden;
+}
+
+.env-key {
+  color: #79c0ff;
   font-weight: 600;
   flex-shrink: 0;
+  min-width: 180px;
 }
 
-.log-message {
-  flex: 1;
-  word-break: break-word;
-}
+.env-key::after { content: '='; color: var(--border-color); }
 
-.log-info .log-level {
-  color: var(--accent);
-}
-
-.log-error .log-level {
-  color: #ff6464;
-}
-
-.log-warn .log-level {
-  color: #ffaa00;
-}
-
-.log-debug .log-level {
+.env-value {
   color: var(--text-secondary);
+  word-break: break-all;
+}
+
+.env-value--redacted {
+  color: #d29922;
+  letter-spacing: 2px;
+}
+
+/* Container info */
+.container-info {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.info-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 8px 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+}
+
+.info-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--text-secondary);
+  min-width: 100px;
+  flex-shrink: 0;
+  padding-top: 1px;
+}
+
+.info-value {
+  font-size: 13px;
+  color: var(--text-primary);
+  word-break: break-all;
+}
+
+.info-value--mono {
+  font-family: monospace;
+  color: var(--text-mono);
 }

--- a/internal/ui/src/components/AppDetail.jsx
+++ b/internal/ui/src/components/AppDetail.jsx
@@ -1,59 +1,216 @@
-import { useState, useEffect } from 'preact/hooks'
+import { useState, useEffect, useRef } from 'preact/hooks'
 import './AppDetail.css'
 
-export function AppDetail({ app, onClose }) {
-  const [logs, setLogs] = useState([])
+function formatRelative(dateStr) {
+  if (!dateStr) return ''
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const s = Math.floor(diff / 1000)
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  return `${Math.floor(h / 24)}d ago`
+}
+
+function formatDateTime(dateStr) {
+  if (!dateStr) return ''
+  return new Date(dateStr).toLocaleString()
+}
+
+function classifyLog(text) {
+  const l = text.toLowerCase()
+  if (l.includes('error') || l.includes('fatal') || l.includes('panic') || l.includes('critical')) return 'log-error'
+  if (l.includes('warn')) return 'log-warn'
+  if (l.includes('debug') || l.includes('trace')) return 'log-debug'
+  return ''
+}
+
+export function AppDetail({ stack, onClose }) {
+  const [selectedContainer, setSelectedContainer] = useState(
+    stack.containers?.[0]?.name ?? null
+  )
 
   useEffect(() => {
-    const es = new EventSource(`/api/logs/${app.id}`)
+    setSelectedContainer(stack.containers?.[0]?.name ?? null)
+  }, [stack.name, stack.repoName])
 
-    es.onmessage = (event) => {
-      setLogs(prev => [...prev, event.data].slice(-100))
-    }
-
-    es.onerror = () => {
-      es.close()
-    }
-
-    return () => {
-      es.close()
-    }
-  }, [app.id])
+  const container = stack.containers?.find(c => c.name === selectedContainer)
 
   return (
     <div class="app-detail">
       <div class="detail-header">
-        <h1>{app.name}</h1>
-        <button class="close-btn" onClick={onClose}>✕</button>
+        <div class="detail-header__title">
+          <span class="detail-repo">{stack.repoName}</span>
+          <span class="detail-sep">/</span>
+          <h2 class="detail-stack-name">{stack.name}</h2>
+          {stack.status && (
+            <span class={`stack-badge stack-badge--${stack.status}`}>{stack.status}</span>
+          )}
+        </div>
+        <button class="close-btn" onClick={onClose} title="Close">✕</button>
       </div>
 
-      <div class="detail-info">
-        <div class="info-row">
-          <span class="label">Status:</span>
-          <span class={`status-badge status-${app.status}`}>{app.status}</span>
-        </div>
-        {app.version && (
-          <div class="info-row">
-            <span class="label">Image:</span>
-            <span>{app.version}</span>
+      <div class="stack-meta-grid">
+        {stack.lastApply && (
+          <div class="meta-item">
+            <span class="meta-label">Last deployed</span>
+            <span class="meta-value">{formatRelative(stack.lastApply)}</span>
+          </div>
+        )}
+        {stack.stackDir && (
+          <div class="meta-item">
+            <span class="meta-label">Directory</span>
+            <span class="meta-value meta-value--mono">{stack.stackDir}</span>
+          </div>
+        )}
+        {stack.lastError && (
+          <div class="meta-item meta-item--error">
+            <span class="meta-label">Error</span>
+            <span class="meta-value">{stack.lastError}</span>
           </div>
         )}
       </div>
 
-      <div class="logs-container">
-        <h3>Live Logs</h3>
-        <div class="logs-content">
-          {logs.length > 0 ? (
-            logs.map((line, idx) => (
-              <div key={idx} class="log-line">
-                {line}
-              </div>
-            ))
-          ) : (
-            <div class="log-line log-info">Waiting for logs...</div>
-          )}
+      {stack.containers?.length > 0 ? (
+        <>
+          <div class="container-tabs">
+            {stack.containers.map(c => (
+              <button
+                key={c.name}
+                class={`container-tab ${c.name === selectedContainer ? 'container-tab--active' : ''}`}
+                onClick={() => setSelectedContainer(c.name)}
+              >
+                <span class={`status-dot status-dot--${c.status}`} />
+                {c.name}
+              </button>
+            ))}
+          </div>
+          {container && <ContainerDetail container={container} />}
+        </>
+      ) : (
+        <div class="empty-state" style={{ padding: '40px', textAlign: 'center', color: 'var(--text-secondary)' }}>
+          No containers found for this stack.
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ContainerDetail({ container }) {
+  const [tab, setTab] = useState('logs')
+
+  return (
+    <div class="container-detail">
+      <div class="info-tabs">
+        {[['logs', '📋 Logs'], ['env', '⚙ Env'], ['info', 'ℹ Info']].map(([t, label]) => (
+          <button
+            key={t}
+            class={`info-tab ${tab === t ? 'info-tab--active' : ''}`}
+            onClick={() => setTab(t)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      {tab === 'logs' && <LogStream key={container.name} containerName={container.name} />}
+      {tab === 'env' && <EnvVars envs={container.env} />}
+      {tab === 'info' && <ContainerInfo container={container} />}
+    </div>
+  )
+}
+
+function LogStream({ containerName }) {
+  const [logs, setLogs] = useState([])
+  const endRef = useRef(null)
+
+  useEffect(() => {
+    setLogs([])
+    const es = new EventSource(`/api/logs/${containerName}`)
+    es.onmessage = e => {
+      setLogs(prev => [...prev, { text: e.data, time: new Date() }].slice(-200))
+    }
+    es.onerror = () => es.close()
+    return () => es.close()
+  }, [containerName])
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [logs])
+
+  return (
+    <div class="logs-content">
+      {!logs.length && <div class="logs-empty">Waiting for logs…</div>}
+      {logs.map((entry, i) => (
+        <div key={i} class={`log-line ${classifyLog(entry.text)}`}>
+          <span class="log-time">{entry.time.toLocaleTimeString()}</span>
+          <span class="log-text">{entry.text}</span>
+        </div>
+      ))}
+      <div ref={endRef} />
+    </div>
+  )
+}
+
+function EnvVars({ envs }) {
+  if (!envs?.length) {
+    return (
+      <div class="env-list">
+        <div style={{ color: 'var(--text-secondary)', padding: '20px', textAlign: 'center' }}>
+          No environment variables available.
         </div>
       </div>
+    )
+  }
+  return (
+    <div class="env-list">
+      {envs.map((e, i) => {
+        const eq = e.indexOf('=')
+        const key = eq >= 0 ? e.slice(0, eq) : e
+        const val = eq >= 0 ? e.slice(eq + 1) : ''
+        const isRedacted = val === '[redacted]'
+        return (
+          <div key={i} class="env-item">
+            <span class="env-key">{key}</span>
+            <span class={`env-value ${isRedacted ? 'env-value--redacted' : ''}`}>
+              {isRedacted ? '••••••' : val}
+            </span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function ContainerInfo({ container }) {
+  return (
+    <div class="container-info">
+      {container.id && (
+        <div class="info-row">
+          <span class="info-label">Container ID</span>
+          <span class="info-value info-value--mono">{container.id.slice(0, 12)}</span>
+        </div>
+      )}
+      <div class="info-row">
+        <span class="info-label">Image</span>
+        <span class="info-value info-value--mono">{container.image || '—'}</span>
+      </div>
+      <div class="info-row">
+        <span class="info-label">Status</span>
+        <span class="info-value">{container.status || '—'}</span>
+      </div>
+      {container.startedAt && container.startedAt !== '0001-01-01T00:00:00Z' && (
+        <div class="info-row">
+          <span class="info-label">Started</span>
+          <span class="info-value">{formatRelative(container.startedAt)} · {formatDateTime(container.startedAt)}</span>
+        </div>
+      )}
+      {container.ports?.length > 0 && (
+        <div class="info-row">
+          <span class="info-label">Ports</span>
+          <span class="info-value info-value--mono">{container.ports.join(', ')}</span>
+        </div>
+      )}
     </div>
   )
 }

--- a/internal/ui/src/components/AppGrid.css
+++ b/internal/ui/src/components/AppGrid.css
@@ -1,61 +1,209 @@
 .app-grid {
-  padding: 20px;
-  height: 100%;
+  padding: 0;
 }
 
-.app-grid h2 {
-  margin-top: 0;
-  margin-bottom: 20px;
-  color: var(--text-primary);
-  font-size: 18px;
-}
-
-.grid-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.grid-item {
-  padding: 12px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.grid-item:hover {
-  background: #353535;
-  border-color: var(--accent);
-}
-
-.app-name {
-  font-weight: 500;
-  color: var(--text-primary);
-  margin-bottom: 6px;
-}
-
-.app-status {
-  font-size: 12px;
-  padding: 4px 8px;
-  border-radius: 3px;
-  display: inline-block;
-  font-weight: 600;
-}
-
-.app-status[data-status="running"] {
-  background: rgba(0, 212, 255, 0.1);
-  color: var(--accent);
-}
-
-.app-status[data-status="stopped"] {
-  background: rgba(255, 100, 100, 0.1);
-  color: #ff6464;
-}
-
+/* Empty state */
 .empty-state {
   padding: 40px 20px;
   text-align: center;
   color: var(--text-secondary);
+}
+
+.empty-state__hint {
+  font-size: 12px;
+  margin-top: 8px;
+  opacity: 0.7;
+}
+
+/* Repo group */
+.repo-group {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.repo-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  background: var(--bg-tertiary);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.repo-header__left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.repo-header__right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.repo-name {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.repo-sha {
+  font-family: monospace;
+  font-size: 11px;
+  color: var(--text-secondary);
+  background: var(--bg-primary);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
+}
+
+.repo-last-sync {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.repo-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.repo-status-dot--ok { background: var(--status-running); }
+.repo-status-dot--error { background: var(--status-error); }
+.repo-status-dot--syncing { background: var(--status-syncing); animation: spin 1.5s linear infinite; border-radius: 0; clip-path: polygon(50% 0%, 100% 100%, 0% 100%); }
+
+.repo-error {
+  margin: 0 16px 8px;
+  padding: 6px 10px;
+  font-size: 12px;
+  color: #f85149;
+  background: rgba(248, 81, 73, 0.08);
+  border-left: 2px solid #f85149;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+/* Sync button */
+.sync-btn {
+  background: none;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  width: 26px;
+  height: 26px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+  flex-shrink: 0;
+}
+
+.sync-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-dim);
+}
+
+.sync-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sync-btn--spinning {
+  animation: spin 1s linear infinite;
+}
+
+/* Stack list */
+.stack-list {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.empty-stacks {
+  padding: 8px 8px 4px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+/* Stack card */
+.stack-card {
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  cursor: pointer;
+  transition: all 0.15s;
+  background: var(--bg-primary);
+}
+
+.stack-card:hover {
+  border-color: rgba(0, 212, 255, 0.3);
+  background: rgba(0, 212, 255, 0.04);
+}
+
+.stack-card--selected {
+  border-color: var(--accent) !important;
+  background: var(--accent-dim) !important;
+}
+
+.stack-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.stack-card__name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.stack-card__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.stack-error {
+  margin-top: 6px;
+  font-size: 11px;
+  color: #f85149;
+}
+
+/* Stack badges */
+.stack-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  flex-shrink: 0;
+}
+
+.stack-badge--running { background: rgba(63, 185, 80, 0.15); color: var(--status-running); border: 1px solid rgba(63,185,80,0.3); }
+.stack-badge--stopped { background: rgba(248, 81, 73, 0.12); color: var(--status-stopped); border: 1px solid rgba(248,81,73,0.25); }
+.stack-badge--degraded { background: rgba(210, 153, 34, 0.12); color: var(--status-degraded); border: 1px solid rgba(210,153,34,0.25); }
+.stack-badge--error { background: rgba(248, 81, 73, 0.12); color: var(--status-error); border: 1px solid rgba(248,81,73,0.25); }
+.stack-badge--applying { background: rgba(88, 166, 255, 0.12); color: var(--status-applying); border: 1px solid rgba(88,166,255,0.25); animation: pulse 1.5s ease-in-out infinite; }
+.stack-badge--unknown { background: rgba(139, 148, 158, 0.12); color: var(--status-unknown); border: 1px solid rgba(139,148,158,0.25); }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
 }

--- a/internal/ui/src/components/AppGrid.jsx
+++ b/internal/ui/src/components/AppGrid.jsx
@@ -1,27 +1,127 @@
 import './AppGrid.css'
 
-export function AppGrid({ apps, onSelect }) {
+function formatRelative(dateStr) {
+  if (!dateStr) return ''
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const s = Math.floor(diff / 1000)
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  return `${Math.floor(h / 24)}d ago`
+}
+
+function deriveStackStatus(stack) {
+  if (stack.status === 'error') return 'error'
+  if (stack.status === 'applying') return 'applying'
+  const containers = stack.containers || []
+  if (!containers.length) return 'unknown'
+  if (containers.every(c => c.status === 'running')) return 'running'
+  if (containers.some(c => c.status === 'running')) return 'degraded'
+  return 'stopped'
+}
+
+export function AppGrid({ repos, selectedStack, syncingRepos, onSelectStack, onForceSync }) {
+  if (!repos.length) {
+    return (
+      <div class="empty-state">
+        <p>No repositories found</p>
+        <p class="empty-state__hint">Mount git repos into REPOS_DIR to get started.</p>
+      </div>
+    )
+  }
+
   return (
     <div class="app-grid">
-      <h2>Applications</h2>
-      <div class="grid-list">
-        {apps.length > 0 ? (
-          apps.map(app => (
-            <div
-              key={app.id}
-              class="grid-item"
-              onClick={() => onSelect(app)}
-            >
-              <div class="app-name">{app.name}</div>
-              <div class="app-status" data-status={app.status}>
-                {app.status}
-              </div>
-            </div>
+      {repos.map(repo => (
+        <RepoGroup
+          key={repo.name}
+          repo={repo}
+          selectedStack={selectedStack}
+          isSyncing={syncingRepos.has(repo.name)}
+          onSelectStack={onSelectStack}
+          onForceSync={onForceSync}
+        />
+      ))}
+    </div>
+  )
+}
+
+function RepoGroup({ repo, selectedStack, isSyncing, onSelectStack, onForceSync }) {
+  return (
+    <div class="repo-group">
+      <div class="repo-header">
+        <div class="repo-header__left">
+          <span class={`repo-status-dot repo-status-dot--${repo.status}`} />
+          <span class="repo-name">{repo.name}</span>
+          {repo.lastSha && (
+            <span class="repo-sha">{repo.lastSha.slice(0, 7)}</span>
+          )}
+        </div>
+        <div class="repo-header__right">
+          {repo.lastSync && (
+            <span class="repo-last-sync">{formatRelative(repo.lastSync)}</span>
+          )}
+          <button
+            class={`sync-btn ${isSyncing ? 'sync-btn--spinning' : ''}`}
+            onClick={() => onForceSync(repo.name)}
+            title={isSyncing ? 'Syncing…' : 'Force git sync'}
+            disabled={isSyncing}
+          >
+            ↻
+          </button>
+        </div>
+      </div>
+
+      {repo.lastError && (
+        <div class="repo-error">{repo.lastError}</div>
+      )}
+
+      <div class="stack-list">
+        {(repo.stacks || []).length > 0 ? (
+          repo.stacks.map(stack => (
+            <StackCard
+              key={stack.name}
+              stack={stack}
+              isSelected={
+                selectedStack?.name === stack.name &&
+                selectedStack?.repoName === repo.name
+              }
+              onSelect={() => onSelectStack({ ...stack, repoName: repo.name })}
+            />
           ))
         ) : (
-          <div class="empty-state">No applications found</div>
+          <div class="empty-stacks">No stacks configured</div>
         )}
       </div>
+    </div>
+  )
+}
+
+function StackCard({ stack, isSelected, onSelect }) {
+  const status = deriveStackStatus(stack)
+  const running = (stack.containers || []).filter(c => c.status === 'running').length
+  const total = (stack.containers || []).length
+
+  return (
+    <div
+      class={`stack-card stack-card--${status} ${isSelected ? 'stack-card--selected' : ''}`}
+      onClick={onSelect}
+    >
+      <div class="stack-card__header">
+        <span class="stack-card__name">{stack.name}</span>
+        <span class={`stack-badge stack-badge--${status}`}>{status}</span>
+      </div>
+      <div class="stack-card__meta">
+        <span class="container-count">{running}/{total} running</span>
+        {stack.lastApply && (
+          <span class="stack-last-apply">{formatRelative(stack.lastApply)}</span>
+        )}
+      </div>
+      {stack.lastError && (
+        <div class="stack-error">{stack.lastError}</div>
+      )}
     </div>
   )
 }

--- a/internal/ui/src/index.css
+++ b/internal/ui/src/index.css
@@ -1,4 +1,4 @@
-* {
+*, *::before, *::after {
   box-sizing: border-box;
 }
 
@@ -9,6 +9,43 @@ html, body, #app {
   padding: 0;
 }
 
-html {
-  background: #1a1a1a;
+:root {
+  --bg-primary: #0d1117;
+  --bg-secondary: #161b22;
+  --bg-tertiary: #21262d;
+  --border-color: #30363d;
+  --text-primary: #e6edf3;
+  --text-secondary: #8b949e;
+  --text-mono: #79c0ff;
+  --accent: #00d4ff;
+  --accent-dim: rgba(0, 212, 255, 0.12);
+  --status-running: #3fb950;
+  --status-stopped: #f85149;
+  --status-degraded: #d29922;
+  --status-applying: #58a6ff;
+  --status-error: #f85149;
+  --status-unknown: #8b949e;
+  --status-syncing: #58a6ff;
+  --status-ok: #3fb950;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 14px;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  line-height: 1.5;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
 }


### PR DESCRIPTION
## Phase 4: UI Modernisation

### Backend changes
- `ContainerDetail` gains `Env []string` and `Ports []string` fields
- `maskEnvVars()` helper redacts sensitive keys (TOKEN, SECRET, KEY, PASSWORD patterns)
- Ports formatted as `hostPort:containerPort/proto`

### Frontend changes
- **Hierarchy restored** — sidebar shows Repo → Stack → Container tree (was flat list)
- **Force sync button** per repo with spin animation
- **Larger logo** in header with Infisical badge indicator
- **Container detail tabs**: Logs, Env vars, Info
- **Docker env vars** displayed with sensitive values masked as ••••••
- **Container ports** and uptime shown in Info tab
- **Log viewer** with timestamps and error/warn/debug colour coding
- **5-second auto-refresh** with error banner and Retry button
- **HTML title** fixed from 'SimpleGithubSync' → 'stackd'
- **Mobile responsive** layout
- **CSS design system** with variables (GitHub dark palette)

### Verified
- `go build ./...` ✅
- `npm run build` ✅