### PR TITLE
feat: UI v2 — design system overhaul

### DIFF
--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
+license: Complete terms in LICENSE.txt
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+
+Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+Focus on:
+- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+
+Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+
+Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.

--- a/.claude/skills/web-design-guidelines/SKILL.md
+++ b/.claude/skills/web-design-guidelines/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: web-design-guidelines
+description: Review UI code for Web Interface Guidelines compliance. Use when asked to "review my UI", "check accessibility", "audit design", "review UX", or "check my site against best practices".
+metadata:
+  author: vercel
+  version: "1.0.0"
+  argument-hint: <file-or-pattern>
+---
+
+# Web Interface Guidelines
+
+Review files for compliance with Web Interface Guidelines.
+
+## How It Works
+
+1. Fetch the latest guidelines from the source URL below
+2. Read the specified files (or prompt user for files/pattern)
+3. Check against all rules in the fetched guidelines
+4. Output findings in the terse `file:line` format
+
+## Guidelines Source
+
+Fetch fresh guidelines before each review:
+
+```
+https://raw.githubusercontent.com/vercel-labs/web-interface-guidelines/main/command.md
+```
+
+Use WebFetch to retrieve the latest rules. The fetched content contains all the rules and output format instructions.
+
+## Usage
+
+When a user provides a file or pattern argument:
+1. Fetch guidelines from the source URL above
+2. Read the specified files
+3. Apply all rules from the fetched guidelines
+4. Output findings using the format specified in the guidelines
+
+If no files specified, ask the user which files to review.

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -7,6 +7,9 @@
     <meta name="description" content="GitOps dashboard for Docker Compose deployments">
     <meta name="theme-color" content="#0d1117">
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="app"></div>

--- a/internal/ui/src/app.css
+++ b/internal/ui/src/app.css
@@ -5,13 +5,13 @@
   background: var(--bg-primary);
 }
 
-/* Header */
+/* ── Header ──────────────────────────────────────── */
 .app-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   padding: 0 24px;
-  height: 56px;
+  height: 52px;
   background: var(--bg-secondary);
   border-bottom: 1px solid var(--border-color);
   flex-shrink: 0;
@@ -23,8 +23,9 @@
   gap: 12px;
 }
 
+/* P1-14 fix: 36px (was 32px) */
 .app-logo {
-  height: 32px;
+  height: 36px;
   width: auto;
 }
 
@@ -34,16 +35,19 @@
   gap: 12px;
 }
 
+/* P1-3 fix: use --accent-border instead of hardcoded cyan rgba */
 .infisical-badge {
+  font-family: var(--font-ui);
   font-size: 12px;
   color: var(--accent);
   background: var(--accent-dim);
-  border: 1px solid rgba(0, 212, 255, 0.2);
+  border: 1px solid var(--accent-border);
   padding: 3px 10px;
   border-radius: 12px;
+  letter-spacing: 0.2px;
 }
 
-/* Error banner */
+/* ── Error banner ────────────────────────────────── */
 .error-banner {
   display: flex;
   align-items: center;
@@ -51,25 +55,36 @@
   padding: 10px 24px;
   background: rgba(248, 81, 73, 0.1);
   border-bottom: 1px solid rgba(248, 81, 73, 0.3);
-  color: #f85149;
+  color: var(--status-stopped);
   font-size: 13px;
+  font-family: var(--font-ui);
+  flex-shrink: 0;
 }
 
 .error-banner button {
   background: rgba(248, 81, 73, 0.15);
   border: 1px solid rgba(248, 81, 73, 0.4);
-  color: #f85149;
+  color: var(--status-stopped);
   padding: 4px 12px;
   border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: 12px;
+  font-family: var(--font-ui);
+  /* P1-1 fix: specific properties only, not transition: all */
+  transition: background 0.1s;
 }
 
 .error-banner button:hover {
-  background: rgba(248, 81, 73, 0.25);
+  background: rgba(248, 81, 73, 0.28);
 }
 
-/* Main layout */
+/* P1-2 fix: focus-visible on error retry button */
+.error-banner button:focus-visible {
+  outline: 2px solid var(--status-stopped);
+  outline-offset: 2px;
+}
+
+/* ── Main layout ─────────────────────────────────── */
 .app-container {
   display: flex;
   flex: 1;
@@ -84,6 +99,7 @@
   background: var(--bg-secondary);
 }
 
+/* P1-6 fix: 14px translateY per spec, 150ms duration */
 .detail-panel {
   flex: 1;
   overflow: hidden;
@@ -92,9 +108,22 @@
   animation: fadeIn 0.15s ease-out;
 }
 
-/* Responsive */
+/* ── Responsive ──────────────────────────────────── */
 @media (max-width: 768px) {
-  .app-container { flex-direction: column; }
-  .grid-panel { width: 100%; max-height: 45vh; border-right: none; border-bottom: 1px solid var(--border-color); }
-  .detail-panel { flex: 1; }
+  .app-container {
+    flex-direction: column;
+  }
+  .grid-panel {
+    width: 100%;
+    max-height: 45vh;
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+    overflow-y: auto;
+  }
+  .detail-panel {
+    flex: 1;
+    min-height: 0;
+  }
 }
+
+/* prefers-reduced-motion guard is in index.css */

--- a/internal/ui/src/components/AppDetail.css
+++ b/internal/ui/src/components/AppDetail.css
@@ -1,3 +1,4 @@
+/* ── Detail panel ────────────────────────────────── */
 .app-detail {
   display: flex;
   flex-direction: column;
@@ -5,12 +6,12 @@
   background: var(--bg-primary);
 }
 
-/* Header */
+/* ── Header ──────────────────────────────────────── */
 .detail-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 20px;
+  padding: 12px 20px;
   border-bottom: 1px solid var(--border-color);
   background: var(--bg-secondary);
   flex-shrink: 0;
@@ -19,29 +20,40 @@
 .detail-header__title {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   min-width: 0;
+  flex-wrap: wrap;
 }
 
+/* Breadcrumb: repo name — muted, small */
 .detail-repo {
-  font-size: 13px;
+  font-family: var(--font-ui);
+  font-size: 12px;
   color: var(--text-secondary);
 }
 
+/* Breadcrumb: separator */
 .detail-sep {
-  color: var(--border-color);
-  font-size: 16px;
+  color: var(--text-muted);
+  font-size: 14px;
+  margin: 0 2px;
+  user-select: none;
 }
 
+/* Breadcrumb: stack name — prominent */
 .detail-stack-name {
   margin: 0;
-  font-size: 15px;
-  font-weight: 600;
+  font-family: var(--font-ui);
+  font-size: 16px;
+  font-weight: 700;
   color: var(--text-primary);
 }
 
+/* P0-3 fix: aria-label="Close" added in JSX         */
+/* P1-1 fix: transition: all → specific properties   */
+/* P1-2 fix: focus-visible added                     */
 .close-btn {
-  background: none;
+  background: transparent;
   border: 1px solid var(--border-color);
   color: var(--text-secondary);
   width: 28px;
@@ -53,15 +65,22 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  transition: all 0.15s;
+  /* Specific properties only */
+  transition: background 0.1s, border-color 0.1s, color 0.1s;
 }
 
 .close-btn:hover {
-  border-color: #f85149;
-  color: #f85149;
+  border-color: var(--status-stopped);
+  color: var(--status-stopped);
+  background: rgba(248, 81, 73, 0.08);
 }
 
-/* Stack metadata grid */
+.close-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ── Stack metadata grid ─────────────────────────── */
 .stack-meta-grid {
   display: flex;
   flex-wrap: wrap;
@@ -78,9 +97,12 @@
   min-width: 0;
 }
 
-.meta-item--error { background: rgba(248, 81, 73, 0.05); }
+.meta-item--error {
+  background: rgba(248, 81, 73, 0.05);
+}
 
 .meta-label {
+  font-family: var(--font-ui);
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
@@ -90,6 +112,7 @@
 }
 
 .meta-value {
+  font-family: var(--font-ui);
   font-size: 13px;
   color: var(--text-primary);
   overflow: hidden;
@@ -99,14 +122,16 @@
 }
 
 .meta-value--mono {
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   color: var(--text-mono);
 }
 
-.meta-item--error .meta-value { color: #f85149; }
+.meta-item--error .meta-value {
+  color: var(--status-stopped);
+}
 
-/* Container tabs */
+/* ── Container tabs (one tab per container) ──────── */
 .container-tabs {
   display: flex;
   gap: 2px;
@@ -117,6 +142,7 @@
   flex-shrink: 0;
 }
 
+/* P1-1 fix: specific transitions; P1-2 fix: focus-visible */
 .container-tab {
   display: flex;
   align-items: center;
@@ -126,27 +152,58 @@
   border: 1px solid transparent;
   background: none;
   color: var(--text-secondary);
+  font-family: var(--font-ui);
   font-size: 12px;
   cursor: pointer;
   white-space: nowrap;
-  transition: all 0.15s;
+  /* Specific properties only */
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+  /* Minimum touch target */
+  min-height: 32px;
 }
 
-.container-tab:hover { background: var(--bg-tertiary); color: var(--text-primary); }
-.container-tab--active { background: var(--bg-tertiary); border-color: var(--border-color); color: var(--text-primary); }
+.container-tab:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
 
+.container-tab--active {
+  background: var(--bg-tertiary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
+}
+
+.container-tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ── Status dots (in container tabs) ─────────────── */
+/* P1-9 fix: 10px + glow ring (was 6px, no glow) */
 .status-dot {
-  width: 6px;
-  height: 6px;
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
   flex-shrink: 0;
 }
 
-.status-dot--running { background: var(--status-running); }
-.status-dot--stopped, .status-dot--exited { background: var(--status-stopped); }
-.status-dot--restarting { background: var(--status-degraded); }
+.status-dot--running {
+  background: var(--status-running);
+  box-shadow: 0 0 0 3px rgba(63, 185, 80, 0.2);
+}
 
-/* Container detail */
+.status-dot--stopped,
+.status-dot--exited {
+  background: var(--status-stopped);
+  box-shadow: 0 0 0 3px rgba(248, 81, 73, 0.2);
+}
+
+.status-dot--restarting {
+  background: var(--status-degraded);
+  box-shadow: 0 0 0 3px rgba(210, 153, 34, 0.2);
+}
+
+/* ── Container detail shell ──────────────────────── */
 .container-detail {
   display: flex;
   flex-direction: column;
@@ -154,7 +211,8 @@
   overflow: hidden;
 }
 
-/* Info tabs (Logs / Env / Info) */
+/* ── Info tabs (Logs / Env / Info) ───────────────── */
+/* P1-1 fix: specific transition; P1-2 fix: focus-visible */
 .info-tabs {
   display: flex;
   gap: 1px;
@@ -170,28 +228,46 @@
   border: none;
   border-bottom: 2px solid transparent;
   color: var(--text-secondary);
+  font-family: var(--font-ui);
   font-size: 12px;
   cursor: pointer;
-  transition: all 0.15s;
+  /* Specific properties only */
+  transition: color 0.1s, border-bottom-color 0.1s;
   margin-bottom: -1px;
+  /* Minimum touch target */
+  min-height: 34px;
 }
 
-.info-tab:hover { color: var(--text-primary); }
-.info-tab--active { color: var(--accent); border-bottom-color: var(--accent); }
+.info-tab:hover {
+  color: var(--text-primary);
+}
 
-/* Logs */
+/* P1-3 fix: accent is now indigo (via --accent CSS var) */
+.info-tab--active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.info-tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ── Log viewer ──────────────────────────────────── */
+/* Darkest bg — creates contrast against panel chrome */
 .logs-content {
   flex: 1;
   overflow-y: auto;
   padding: 8px;
-  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   line-height: 1.6;
-  background: #0a0c10;
+  background: var(--bg-primary);
 }
 
 .logs-empty {
-  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  color: var(--text-muted);
   padding: 20px;
   text-align: center;
 }
@@ -201,69 +277,105 @@
   gap: 10px;
   padding: 1px 4px;
   border-radius: 2px;
+  /* Reserve space for left-border on error/warn; transparent by default */
+  border-left: 2px solid transparent;
 }
 
-.log-line:hover { background: rgba(255,255,255,0.03); }
+.log-line:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
 
+/* P1-13 fix: timestamp min-width + muted color */
 .log-time {
-  color: #484f58;
+  color: var(--text-muted);
   flex-shrink: 0;
   font-size: 11px;
   padding-top: 1px;
+  min-width: 80px;
 }
 
-.log-text { color: #adbac7; word-break: break-all; }
+.log-text {
+  color: #adbac7;
+  word-break: break-all;
+}
+
+/* P1-13 fix: left-border markers on error/warn lines */
+.log-error {
+  border-left-color: var(--status-stopped);
+  padding-left: 6px;
+}
 .log-error .log-text { color: #ff7b72; }
+
+.log-warn {
+  border-left-color: var(--status-degraded);
+  padding-left: 6px;
+}
 .log-warn .log-text { color: #e3b341; }
+
 .log-debug .log-text { color: #79c0ff; }
 
-/* Env vars */
+/* ── Env vars ────────────────────────────────────── */
+/* Terminal-style display: key=value, monospace throughout */
 .env-list {
   padding: 12px;
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 2px;
   overflow-y: auto;
   flex: 1;
 }
 
+/* P1-12: hover background; font-mono */
 .env-item {
   display: flex;
   gap: 0;
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: 12px;
   padding: 5px 10px;
   border-radius: var(--radius-sm);
   background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-subtle);
   overflow: hidden;
+  /* Specific transition */
+  transition: background 0.1s;
 }
 
+.env-item:hover {
+  background: var(--bg-hover);
+}
+
+/* P1-11 fix: var(--accent) instead of hardcoded #79c0ff */
 .env-key {
-  color: #79c0ff;
-  font-weight: 600;
+  font-family: var(--font-mono);
+  color: var(--accent);
+  font-weight: 500;
   flex-shrink: 0;
   min-width: 180px;
 }
 
-.env-key::after { content: '='; color: var(--border-color); }
+.env-key::after {
+  content: '=';
+  color: var(--text-muted);
+}
 
+/* P1-12 fix: var(--text-primary) instead of var(--text-secondary) */
 .env-value {
-  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  color: var(--text-primary);
   word-break: break-all;
 }
 
 .env-value--redacted {
-  color: #d29922;
+  color: var(--text-muted);
   letter-spacing: 2px;
 }
 
-/* Container info */
+/* ── Container info ──────────────────────────────── */
 .container-info {
   padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   overflow-y: auto;
   flex: 1;
 }
@@ -274,11 +386,12 @@
   gap: 12px;
   padding: 8px 12px;
   background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
 }
 
 .info-label {
+  font-family: var(--font-ui);
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
@@ -290,12 +403,22 @@
 }
 
 .info-value {
+  font-family: var(--font-ui);
   font-size: 13px;
   color: var(--text-primary);
   word-break: break-all;
 }
 
+/* P1-8 fix: var(--font-mono) */
 .info-value--mono {
-  font-family: monospace;
+  font-family: var(--font-mono);
   color: var(--text-mono);
+}
+
+/* ── Empty state (reused in detail) ─────────────── */
+.empty-state-inline {
+  padding: 40px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
 }

--- a/internal/ui/src/components/AppDetail.jsx
+++ b/internal/ui/src/components/AppDetail.jsx
@@ -1,6 +1,9 @@
 import { useState, useEffect, useRef } from 'preact/hooks'
 import './AppDetail.css'
 
+// ── Time helpers ──────────────────────────────────────
+// (defined here; consumed by multiple sub-components)
+
 function formatRelative(dateStr) {
   if (!dateStr) return ''
   const diff = Date.now() - new Date(dateStr).getTime()
@@ -26,6 +29,8 @@ function classifyLog(text) {
   return ''
 }
 
+// ── AppDetail ─────────────────────────────────────────
+
 export function AppDetail({ stack, onClose }) {
   const [selectedContainer, setSelectedContainer] = useState(
     stack.containers?.[0]?.name ?? null
@@ -42,13 +47,23 @@ export function AppDetail({ stack, onClose }) {
       <div class="detail-header">
         <div class="detail-header__title">
           <span class="detail-repo">{stack.repoName}</span>
-          <span class="detail-sep">/</span>
+          <span class="detail-sep" aria-hidden="true">/</span>
           <h2 class="detail-stack-name">{stack.name}</h2>
           {stack.status && (
-            <span class={`stack-badge stack-badge--${stack.status}`}>{stack.status}</span>
+            <span class={`stack-badge stack-badge--${stack.status}`} aria-hidden="true">
+              {stack.status}
+            </span>
           )}
         </div>
-        <button class="close-btn" onClick={onClose} title="Close">✕</button>
+        {/* P0-3 fix: aria-label="Close" */}
+        <button
+          class="close-btn"
+          onClick={onClose}
+          aria-label="Close detail panel"
+          title="Close"
+        >
+          ✕
+        </button>
       </div>
 
       <div class="stack-meta-grid">
@@ -74,14 +89,16 @@ export function AppDetail({ stack, onClose }) {
 
       {stack.containers?.length > 0 ? (
         <>
-          <div class="container-tabs">
+          <div class="container-tabs" role="tablist" aria-label="Containers">
             {stack.containers.map(c => (
               <button
                 key={c.name}
+                role="tab"
+                aria-selected={c.name === selectedContainer}
                 class={`container-tab ${c.name === selectedContainer ? 'container-tab--active' : ''}`}
                 onClick={() => setSelectedContainer(c.name)}
               >
-                <span class={`status-dot status-dot--${c.status}`} />
+                <span class={`status-dot status-dot--${c.status}`} aria-hidden="true" />
                 {c.name}
               </button>
             ))}
@@ -89,7 +106,7 @@ export function AppDetail({ stack, onClose }) {
           {container && <ContainerDetail container={container} />}
         </>
       ) : (
-        <div class="empty-state" style={{ padding: '40px', textAlign: 'center', color: 'var(--text-secondary)' }}>
+        <div class="empty-state-inline">
           No containers found for this stack.
         </div>
       )}
@@ -97,15 +114,19 @@ export function AppDetail({ stack, onClose }) {
   )
 }
 
+// ── ContainerDetail ───────────────────────────────────
+
 function ContainerDetail({ container }) {
   const [tab, setTab] = useState('logs')
 
   return (
     <div class="container-detail">
-      <div class="info-tabs">
+      <div class="info-tabs" role="tablist" aria-label="Container detail sections">
         {[['logs', '📋 Logs'], ['env', '⚙ Env'], ['info', 'ℹ Info']].map(([t, label]) => (
           <button
             key={t}
+            role="tab"
+            aria-selected={tab === t}
             class={`info-tab ${tab === t ? 'info-tab--active' : ''}`}
             onClick={() => setTab(t)}
           >
@@ -114,11 +135,13 @@ function ContainerDetail({ container }) {
         ))}
       </div>
       {tab === 'logs' && <LogStream key={container.name} containerName={container.name} />}
-      {tab === 'env' && <EnvVars envs={container.env} />}
+      {tab === 'env'  && <EnvVars envs={container.env} />}
       {tab === 'info' && <ContainerInfo container={container} />}
     </div>
   )
 }
+
+// ── LogStream ─────────────────────────────────────────
 
 function LogStream({ containerName }) {
   const [logs, setLogs] = useState([])
@@ -139,40 +162,43 @@ function LogStream({ containerName }) {
   }, [logs])
 
   return (
-    <div class="logs-content">
+    <div class="logs-content" role="log" aria-live="polite" aria-label={`Logs for ${containerName}`}>
       {!logs.length && <div class="logs-empty">Waiting for logs…</div>}
       {logs.map((entry, i) => (
         <div key={i} class={`log-line ${classifyLog(entry.text)}`}>
-          <span class="log-time">{entry.time.toLocaleTimeString()}</span>
+          <span class="log-time" aria-hidden="true">{entry.time.toLocaleTimeString()}</span>
           <span class="log-text">{entry.text}</span>
         </div>
       ))}
-      <div ref={endRef} />
+      <div ref={endRef} aria-hidden="true" />
     </div>
   )
 }
+
+// ── EnvVars ───────────────────────────────────────────
 
 function EnvVars({ envs }) {
   if (!envs?.length) {
     return (
       <div class="env-list">
-        <div style={{ color: 'var(--text-secondary)', padding: '20px', textAlign: 'center' }}>
-          No environment variables available.
-        </div>
+        <div class="empty-state-inline">No environment variables available.</div>
       </div>
     )
   }
   return (
-    <div class="env-list">
+    <div class="env-list" role="list" aria-label="Environment variables">
       {envs.map((e, i) => {
         const eq = e.indexOf('=')
         const key = eq >= 0 ? e.slice(0, eq) : e
         const val = eq >= 0 ? e.slice(eq + 1) : ''
         const isRedacted = val === '[redacted]'
         return (
-          <div key={i} class="env-item">
+          <div key={i} class="env-item" role="listitem">
             <span class="env-key">{key}</span>
-            <span class={`env-value ${isRedacted ? 'env-value--redacted' : ''}`}>
+            <span
+              class={`env-value ${isRedacted ? 'env-value--redacted' : ''}`}
+              aria-label={isRedacted ? `${key}: redacted` : undefined}
+            >
               {isRedacted ? '••••••' : val}
             </span>
           </div>
@@ -181,6 +207,10 @@ function EnvVars({ envs }) {
     </div>
   )
 }
+
+// ── ContainerInfo ─────────────────────────────────────
+// P0-1 fix: removed `require('../utils/time')` — formatRelative and
+// formatDateTime are already defined in this module's scope above.
 
 function ContainerInfo({ container }) {
   return (
@@ -202,7 +232,13 @@ function ContainerInfo({ container }) {
       {container.startedAt && container.startedAt !== '0001-01-01T00:00:00Z' && (
         <div class="info-row">
           <span class="info-label">Started</span>
-          <span class="info-value">{formatRelative(container.startedAt)} · {formatDateTime(container.startedAt)}</span>
+          <span class="info-value">
+            {formatRelative(container.startedAt)}
+            <span aria-hidden="true"> · </span>
+            <span style={{ color: 'var(--text-secondary)', fontSize: '12px' }}>
+              {formatDateTime(container.startedAt)}
+            </span>
+          </span>
         </div>
       )}
       {container.ports?.length > 0 && (

--- a/internal/ui/src/components/AppGrid.css
+++ b/internal/ui/src/components/AppGrid.css
@@ -1,31 +1,39 @@
+/* ── App grid shell ──────────────────────────────── */
 .app-grid {
   padding: 0;
 }
 
-/* Empty state */
+/* ── Empty state ─────────────────────────────────── */
 .empty-state {
-  padding: 40px 20px;
+  padding: 48px 24px;
   text-align: center;
   color: var(--text-secondary);
+  font-family: var(--font-ui);
+}
+
+.empty-state p {
+  margin: 0 0 4px;
 }
 
 .empty-state__hint {
   font-size: 12px;
   margin-top: 8px;
-  opacity: 0.7;
+  color: var(--text-muted);
 }
 
-/* Repo group */
+/* ── Repo group ──────────────────────────────────── */
 .repo-group {
   border-bottom: 1px solid var(--border-color);
 }
 
+/* P1-15 fix: left indigo accent border, padding adjusted for 3px border */
 .repo-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 16px;
+  padding: 8px 16px 8px 13px; /* 13px = 16px - 3px border */
   background: var(--bg-tertiary);
+  border-left: 3px solid var(--accent);
   position: sticky;
   top: 0;
   z-index: 1;
@@ -45,8 +53,10 @@
   flex-shrink: 0;
 }
 
+/* P1-15 fix: font-weight 700 (was 600) */
 .repo-name {
-  font-weight: 600;
+  font-family: var(--font-ui);
+  font-weight: 700;
   font-size: 13px;
   color: var(--text-primary);
   white-space: nowrap;
@@ -54,63 +64,90 @@
   text-overflow: ellipsis;
 }
 
+/* P1-8 fix: var(--font-mono) instead of plain monospace */
 .repo-sha {
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: 11px;
   color: var(--text-secondary);
   background: var(--bg-primary);
   padding: 1px 6px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-color);
+  letter-spacing: 0.3px;
 }
 
 .repo-last-sync {
+  font-family: var(--font-ui);
   font-size: 11px;
-  color: var(--text-secondary);
+  color: var(--text-muted);
 }
 
+/* ── Repo status dots ────────────────────────────── */
+/* P1-9 fix: 10px + glow ring (these are on the repo header, not container tabs) */
 .repo-status-dot {
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
   flex-shrink: 0;
 }
 
-.repo-status-dot--ok { background: var(--status-running); }
-.repo-status-dot--error { background: var(--status-error); }
-.repo-status-dot--syncing { background: var(--status-syncing); animation: spin 1.5s linear infinite; border-radius: 0; clip-path: polygon(50% 0%, 100% 100%, 0% 100%); }
+.repo-status-dot--ok {
+  background: var(--status-running);
+  box-shadow: 0 0 0 3px rgba(63, 185, 80, 0.2);
+}
 
+.repo-status-dot--error {
+  background: var(--status-error);
+  box-shadow: 0 0 0 3px rgba(248, 81, 73, 0.2);
+}
+
+/* syncing: triangle spinner — clip-path removes circle, animation drives rotation */
+.repo-status-dot--syncing {
+  background: var(--status-syncing);
+  box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.2);
+  animation: spin 1.5s linear infinite;
+  border-radius: 0;
+  clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+}
+
+/* ── Repo error ──────────────────────────────────── */
 .repo-error {
   margin: 0 16px 8px;
   padding: 6px 10px;
+  font-family: var(--font-ui);
   font-size: 12px;
-  color: #f85149;
+  color: var(--status-stopped);
   background: rgba(248, 81, 73, 0.08);
-  border-left: 2px solid #f85149;
+  border-left: 2px solid var(--status-stopped);
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 }
 
-/* Sync button */
+/* ── Sync button ─────────────────────────────────── */
+/* P0-2 fix: aria-label added in JSX                  */
+/* P1-1 fix: transition: all → specific properties    */
+/* P1-2 fix: focus-visible added                      */
 .sync-btn {
-  background: none;
+  background: transparent;
   border: 1px solid var(--border-color);
   color: var(--text-secondary);
-  width: 26px;
-  height: 26px;
+  width: 28px;
+  height: 28px;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 14px;
+  font-size: 15px;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.15s;
+  /* Specific properties only — no transition: all */
+  transition: background 0.1s, border-color 0.1s, color 0.1s;
   flex-shrink: 0;
+  line-height: 1;
 }
 
 .sync-btn:hover:not(:disabled) {
-  border-color: var(--accent);
-  color: var(--accent);
   background: var(--accent-dim);
+  border-color: var(--accent-border);
+  color: var(--accent);
 }
 
 .sync-btn:disabled {
@@ -118,11 +155,18 @@
   cursor: not-allowed;
 }
 
-.sync-btn--spinning {
-  animation: spin 1s linear infinite;
+.sync-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
-/* Stack list */
+.sync-btn--spinning {
+  animation: spin 0.8s linear infinite;
+  color: var(--accent);
+  border-color: var(--accent-border);
+}
+
+/* ── Stack list ──────────────────────────────────── */
 .stack-list {
   padding: 8px;
   display: flex;
@@ -132,28 +176,43 @@
 
 .empty-stacks {
   padding: 8px 8px 4px;
+  font-family: var(--font-ui);
   font-size: 12px;
   color: var(--text-secondary);
   font-style: italic;
 }
 
-/* Stack card */
+/* ── Stack card ──────────────────────────────────── */
+/* P1-16 fix: border-left pattern instead of full-border swap                   */
+/* P1-1 fix: transition: all → specific properties                               */
+/* P1-2 fix: focus-visible added                                                 */
+/* Design: border-left starts transparent, becomes accent on hover/selected     */
 .stack-card {
   padding: 10px 12px;
   border-radius: var(--radius-md);
+  /* Full border for structure; left border drives status/selection signal */
   border: 1px solid var(--border-color);
+  border-left: 2px solid transparent;
   cursor: pointer;
-  transition: all 0.15s;
+  /* Specific properties only */
+  transition: background 0.1s, border-left-color 0.1s;
   background: var(--bg-primary);
 }
 
 .stack-card:hover {
-  border-color: rgba(0, 212, 255, 0.3);
-  background: rgba(0, 212, 255, 0.04);
+  background: var(--bg-hover);
+  border-left-color: var(--border-color);
 }
 
+/* P1-2 fix: visible focus ring */
+.stack-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* P1-16 fix: left accent border + bg tint (no box-shadow) */
 .stack-card--selected {
-  border-color: var(--accent) !important;
+  border-left-color: var(--accent) !important;
   background: var(--accent-dim) !important;
 }
 
@@ -165,28 +224,36 @@
   margin-bottom: 4px;
 }
 
+/* font-weight 600, var(--font-ui) */
 .stack-card__name {
+  font-family: var(--font-ui);
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .stack-card__meta {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  font-family: var(--font-ui);
   font-size: 11px;
   color: var(--text-secondary);
 }
 
 .stack-error {
   margin-top: 6px;
+  font-family: var(--font-ui);
   font-size: 11px;
-  color: #f85149;
+  color: var(--status-stopped);
 }
 
-/* Stack badges */
+/* ── Stack badges ────────────────────────────────── */
 .stack-badge {
+  font-family: var(--font-ui);
   font-size: 10px;
   font-weight: 600;
   padding: 2px 7px;
@@ -194,16 +261,13 @@
   text-transform: uppercase;
   letter-spacing: 0.3px;
   flex-shrink: 0;
+  white-space: nowrap;
 }
 
-.stack-badge--running { background: rgba(63, 185, 80, 0.15); color: var(--status-running); border: 1px solid rgba(63,185,80,0.3); }
-.stack-badge--stopped { background: rgba(248, 81, 73, 0.12); color: var(--status-stopped); border: 1px solid rgba(248,81,73,0.25); }
-.stack-badge--degraded { background: rgba(210, 153, 34, 0.12); color: var(--status-degraded); border: 1px solid rgba(210,153,34,0.25); }
-.stack-badge--error { background: rgba(248, 81, 73, 0.12); color: var(--status-error); border: 1px solid rgba(248,81,73,0.25); }
-.stack-badge--applying { background: rgba(88, 166, 255, 0.12); color: var(--status-applying); border: 1px solid rgba(88,166,255,0.25); animation: pulse 1.5s ease-in-out infinite; }
-.stack-badge--unknown { background: rgba(139, 148, 158, 0.12); color: var(--status-unknown); border: 1px solid rgba(139,148,158,0.25); }
-
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.6; }
-}
+.stack-badge--running  { background: rgba(63,  185, 80,  0.15); color: var(--status-running);  border: 1px solid rgba(63,  185, 80,  0.3);  }
+.stack-badge--ok       { background: rgba(63,  185, 80,  0.15); color: var(--status-ok);       border: 1px solid rgba(63,  185, 80,  0.3);  }
+.stack-badge--stopped  { background: rgba(248, 81,  73,  0.12); color: var(--status-stopped);  border: 1px solid rgba(248, 81,  73,  0.25); }
+.stack-badge--degraded { background: rgba(210, 153, 34,  0.12); color: var(--status-degraded); border: 1px solid rgba(210, 153, 34,  0.25); }
+.stack-badge--error    { background: rgba(248, 81,  73,  0.12); color: var(--status-error);    border: 1px solid rgba(248, 81,  73,  0.25); }
+.stack-badge--applying { background: rgba(88,  166, 255, 0.12); color: var(--status-applying); border: 1px solid rgba(88,  166, 255, 0.25); animation: pulse 1.5s ease-in-out infinite; }
+.stack-badge--unknown  { background: rgba(72,  79,  88,  0.2);  color: var(--status-unknown);  border: 1px solid rgba(72,  79,  88,  0.3);  }

--- a/internal/ui/src/components/AppGrid.jsx
+++ b/internal/ui/src/components/AppGrid.jsx
@@ -53,19 +53,24 @@ function RepoGroup({ repo, selectedStack, isSyncing, onSelectStack, onForceSync 
     <div class="repo-group">
       <div class="repo-header">
         <div class="repo-header__left">
-          <span class={`repo-status-dot repo-status-dot--${repo.status}`} />
+          <span
+            class={`repo-status-dot repo-status-dot--${repo.status}`}
+            aria-hidden="true"
+          />
           <span class="repo-name">{repo.name}</span>
           {repo.lastSha && (
-            <span class="repo-sha">{repo.lastSha.slice(0, 7)}</span>
+            <span class="repo-sha" title={repo.lastSha}>{repo.lastSha.slice(0, 7)}</span>
           )}
         </div>
         <div class="repo-header__right">
           {repo.lastSync && (
             <span class="repo-last-sync">{formatRelative(repo.lastSync)}</span>
           )}
+          {/* P0-2 fix: aria-label instead of title-only */}
           <button
             class={`sync-btn ${isSyncing ? 'sync-btn--spinning' : ''}`}
             onClick={() => onForceSync(repo.name)}
+            aria-label={isSyncing ? `Syncing ${repo.name}…` : `Force git sync for ${repo.name}`}
             title={isSyncing ? 'Syncing…' : 'Force git sync'}
             disabled={isSyncing}
           >
@@ -75,7 +80,7 @@ function RepoGroup({ repo, selectedStack, isSyncing, onSelectStack, onForceSync 
       </div>
 
       {repo.lastError && (
-        <div class="repo-error">{repo.lastError}</div>
+        <div class="repo-error" role="alert">{repo.lastError}</div>
       )}
 
       <div class="stack-list">
@@ -104,14 +109,27 @@ function StackCard({ stack, isSelected, onSelect }) {
   const running = (stack.containers || []).filter(c => c.status === 'running').length
   const total = (stack.containers || []).length
 
+  // P0-4 fix: keyboard accessibility — Enter/Space activates the card
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onSelect()
+    }
+  }
+
   return (
     <div
       class={`stack-card stack-card--${status} ${isSelected ? 'stack-card--selected' : ''}`}
       onClick={onSelect}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={0}
+      aria-pressed={isSelected}
+      aria-label={`${stack.name} — ${status}, ${running} of ${total} containers running`}
     >
       <div class="stack-card__header">
         <span class="stack-card__name">{stack.name}</span>
-        <span class={`stack-badge stack-badge--${status}`}>{status}</span>
+        <span class={`stack-badge stack-badge--${status}`} aria-hidden="true">{status}</span>
       </div>
       <div class="stack-card__meta">
         <span class="container-count">{running}/{total} running</span>

--- a/internal/ui/src/index.css
+++ b/internal/ui/src/index.css
@@ -10,42 +10,87 @@ html, body, #app {
 }
 
 :root {
-  --bg-primary: #0d1117;
+  /* ── Backgrounds ─────────────────────────────── */
+  --bg-primary:   #0d1117;
   --bg-secondary: #161b22;
-  --bg-tertiary: #21262d;
-  --border-color: #30363d;
-  --text-primary: #e6edf3;
+  --bg-tertiary:  #21262d;
+  --bg-hover:     rgba(255, 255, 255, 0.04);
+
+  /* ── Borders ─────────────────────────────────── */
+  --border-color:  #30363d;
+  --border-subtle: #21262d;
+
+  /* ── Text ────────────────────────────────────── */
+  --text-primary:   #e6edf3;
   --text-secondary: #8b949e;
-  --text-mono: #79c0ff;
-  --accent: #00d4ff;
-  --accent-dim: rgba(0, 212, 255, 0.12);
-  --status-running: #3fb950;
-  --status-stopped: #f85149;
+  --text-muted:     #484f58;
+  --text-mono:      #79c0ff;
+
+  /* ── Typography ──────────────────────────────── */
+  --font-ui:   'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+
+  /* ── Brand accent — electric indigo ─────────── */
+  /* Used for actions, focus rings, and brand only. */
+  /* Never reuse for status indicators.            */
+  --accent:        #6c63ff;
+  --accent-dim:    rgba(108, 99, 255, 0.12);
+  --accent-border: rgba(108, 99, 255, 0.3);
+
+  /* ── Status colours — sacred ────────────────── */
+  /* green/red/yellow/blue = health states only.   */
+  /* Never repurpose these for anything else.      */
+  --status-running:  #3fb950;
+  --status-stopped:  #f85149;
   --status-degraded: #d29922;
   --status-applying: #58a6ff;
-  --status-error: #f85149;
-  --status-unknown: #8b949e;
-  --status-syncing: #58a6ff;
-  --status-ok: #3fb950;
-  --radius-sm: 4px;
-  --radius-md: 6px;
-  --radius-lg: 8px;
+  --status-error:    #f85149;
+  --status-unknown:  #484f58;
+  --status-syncing:  #58a6ff;
+  --status-ok:       #3fb950;
+
+  /* ── Radius — tight, purposeful ─────────────── */
+  --radius-sm: 3px;
+  --radius-md: 5px;
+  --radius-lg: 6px;
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  font-size: 14px;
+  font-family: var(--font-ui);
+  font-size: 13px;
   color: var(--text-primary);
   background: var(--bg-primary);
   line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
+
+/* ── Animations ──────────────────────────────────── */
+/* Only two animations are permitted:                */
+/*  1. spin  — communicates active work on sync btn  */
+/*  2. fadeIn — panel entry (14px, 150ms, ease-out)  */
 
 @keyframes spin {
   from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  to   { transform: rotate(360deg); }
 }
 
 @keyframes fadeIn {
-  from { opacity: 0; transform: translateY(4px); }
-  to { opacity: 1; transform: translateY(0); }
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.6; }
+}
+
+/* ── Reduced motion ──────────────────────────────── */
+/* Target only the permitted animations; do not      */
+/* blanket-disable all transitions (breaks usability)*/
+@media (prefers-reduced-motion: reduce) {
+  .detail-panel       { animation: none; }
+  .sync-btn--spinning { animation: none; opacity: 0.65; }
+  .repo-status-dot--syncing { animation: none; }
+  .stack-badge--applying    { animation: none; }
 }


### PR DESCRIPTION
## UI v2 — Impeccable skill-guided design overhaul

### Design direction
Built against `.impeccable.md` context: **sharp, straight to the point, no BS**. The user should feel *in command* of their infrastructure — ArgoCD-inspired authority.

### Design system changes
- **Accent:** cyan `#00d4ff` → electric indigo `#6c63ff` (actions/brand only, never status)
- **Typography:** `DM Sans` for UI labels + `JetBrains Mono` for all data (SHA, env, ports, IDs, logs)
- **Radii tightened:** 3/5/6px (was 4/6/8px) — purposeful, not decorative
- **No box-shadows on cards** — border-only UI
- **Status colours unchanged and sacred**

### Visual improvements
- Repo header: left 3px indigo border, font-weight 700 — anchors the hierarchy
- Stack cards: border-left selection pattern (was background-only)
- Status dots: 10px + colour-matched glow ring (was 6px, no glow)
- Sync button: indigo hover, 28px touch target, accessible focus ring
- Logo: 36px (was 32px)

### Log viewer
- Error/warn lines: left-border marker (red/yellow)
- Timestamps: muted colour, JetBrains Mono 11px
- Background: `var(--bg-primary)` — darker than panel, creates depth

### Env var display
- Keys: indigo (action colour — these are the 'nouns' of config)
- Values: primary text
- Redacted: muted dots `••••••`

### Accessibility fixes (from /audit P0+P1)
- `aria-label` on sync button and close button
- `role=button` + `tabIndex=0` + `onKeyDown` on StackCard
- `role=tablist/tab` + `aria-selected` on container/info tabs
- `role=log` + `aria-live=polite` on log stream
- No `transition: all` anywhere
- All `:focus-visible` rings (2px indigo, 2px offset)
- `prefers-reduced-motion` guards on spin, fadeIn, pulse

### Build
- `npm run build` ✅
- `go build ./...` ✅