### PR TITLE
fix: stack card time reflects actual container startedAt

### DIFF
--- a/internal/ui/src/components/AppDetail.jsx
+++ b/internal/ui/src/components/AppDetail.jsx
@@ -69,7 +69,7 @@ export function AppDetail({ stack, onClose }) {
       <div class="stack-meta-grid">
         {stack.lastApply && (
           <div class="meta-item">
-            <span class="meta-label">Last deployed</span>
+        <span class="meta-label">Running since</span>
             <span class="meta-value">{formatRelative(stack.lastApply)}</span>
           </div>
         )}

--- a/main.go
+++ b/main.go
@@ -344,6 +344,20 @@ store.UpdateStackContainers(st.RepoName, st.Name, containers)
 	}
 }
 
+// latestStartedAt returns the most recent StartedAt time across containers,
+// or the zero time if none are present. Used so stack.LastApply reflects
+// when containers actually last changed rather than when stackd last ran.
+func latestStartedAt(containers []state.ContainerDetail) time.Time {
+	var latest time.Time
+	for _, c := range containers {
+		if c.StartedAt.After(latest) {
+			latest = c.StartedAt
+		}
+	}
+	return latest
+}
+
+
 func applyStack(ctx context.Context, stackPath, stackName, repoName string, store *state.Store, dockerClient *docker.Client) {
 if store != nil {
 store.UpdateStack(state.StackState{
@@ -397,6 +411,12 @@ StartedAt: dc.StartedAt,
 				Ports:     dc.Ports,
 			})
 }
+				// Use the most recent container StartedAt so the stack card
+				// shows when containers actually last changed, not when
+				// stackd last ran docker compose (resets on every restart).
+				if latest := latestStartedAt(st.Containers); !latest.IsZero() {
+					st.LastApply = latest
+				}
 }
 }
 }


### PR DESCRIPTION
## Problem

The stack card showed `stack.lastApply` as the time — e.g. "24m ago" — even though the containers had been running for 5 days. This is because `applyStack()` always sets `LastApply = time.Now()` on every call, including the startup scan. Every time stackd restarts, the counter resets to "0s ago".

The container Info tab correctly showed "Started: 5d ago" (from Docker's `ContainerInspect`), so the two values were contradictory.

## Fix

After `docker compose up -d` succeeds, set `LastApply` to the most recent `StartedAt` across all containers in the stack instead of `time.Now()`.

- If containers haven't been restarted (most common case), `LastApply` now correctly reflects "5d ago"
- If a real deploy restarts containers, their `StartedAt` updates to the restart time, so `LastApply` stays accurate
- Added `latestStartedAt()` helper in `main.go`
- Changed label "Last deployed" → "Running since" in the detail panel

**Build:** `go build ./...` ✅  `npm run build` ✅