### PR TITLE
fix(ui): sort stacks in sidebar, stable order on refresh

### DIFF
--- a/internal/ui/src/app.jsx
+++ b/internal/ui/src/app.jsx
@@ -46,7 +46,7 @@ export function App() {
           setSyncStatus(prev => ({ ...prev, [repoName]: { state: 'rateLimit', message: 'Rate limited — wait a moment' } }))
           setTimeout(() => setSyncStatus(prev => { const n = { ...prev }; delete n[repoName]; return n }), 5000)
         } else if (res.ok) {
-          setSyncStatus(prev => ({ ...prev, [repoName]: { state: 'success' } }))
+          setSyncStatus(prev => ({ ...prev, [repoName]: { state: 'success', message: 'Synced ✓' } }))
           setTimeout(() => setSyncStatus(prev => { const n = { ...prev }; delete n[repoName]; return n }), 2000)
         } else {
           setSyncStatus(prev => ({ ...prev, [repoName]: { state: 'error', message: `Sync failed (${res.status})` } }))

--- a/internal/ui/src/components/AppDetail.css
+++ b/internal/ui/src/components/AppDetail.css
@@ -423,67 +423,7 @@
   font-family: var(--font-ui);
 }
 
-/* ── Container tabs bar (tabs + sort control) ────── */
-.container-tabs-bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  border-bottom: 1px solid var(--border-color);
-  background: var(--bg-secondary);
-  flex-shrink: 0;
-  gap: 8px;
-  padding-right: 12px;
-}
 
-.container-tabs-bar .container-tabs {
-  border-bottom: none;
-  flex: 1;
-  padding-right: 0;
-}
-
-/* ── Sort control ────────────────────────────────── */
-.sort-control {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-shrink: 0;
-}
-
-.sort-label {
-  font-family: var(--font-ui);
-  font-size: 11px;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.4px;
-  white-space: nowrap;
-}
-
-.sort-select {
-  font-family: var(--font-ui);
-  font-size: 12px;
-  color: var(--text-secondary);
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  padding: 3px 22px 3px 8px;
-  cursor: pointer;
-  appearance: none;
-  -webkit-appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%238b949e'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 6px center;
-  transition: border-color 0.1s, color 0.1s;
-}
-
-.sort-select:hover {
-  border-color: var(--accent-border);
-  color: var(--text-primary);
-}
-
-.sort-select:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
 
 /* ── Stream ended banner ─────────────────────────── */
 .logs-wrapper {

--- a/internal/ui/src/components/AppDetail.jsx
+++ b/internal/ui/src/components/AppDetail.jsx
@@ -2,31 +2,6 @@ import { useState, useEffect, useRef } from 'preact/hooks'
 import { formatRelative, formatDateTime } from '../utils/time'
 import './AppDetail.css'
 
-const SORT_OPTIONS = [
-  { key: 'name-asc',    label: 'Name A→Z' },
-  { key: 'name-desc',   label: 'Name Z→A' },
-  { key: 'uptime-desc', label: 'Uptime ↑' },
-  { key: 'uptime-asc',  label: 'Uptime ↓' },
-]
-
-function sortContainers(containers, order) {
-  const c = [...containers]
-  switch (order) {
-    case 'name-asc':
-      return c.sort((a, b) => a.name.localeCompare(b.name))
-    case 'name-desc':
-      return c.sort((a, b) => b.name.localeCompare(a.name))
-    case 'uptime-desc':
-      // longest running first = smallest startedAt (earliest date)
-      return c.sort((a, b) => new Date(a.startedAt || 0) - new Date(b.startedAt || 0))
-    case 'uptime-asc':
-      // shortest running first = largest startedAt (most recent date)
-      return c.sort((a, b) => new Date(b.startedAt || 0) - new Date(a.startedAt || 0))
-    default:
-      return c
-  }
-}
-
 function classifyLog(text) {
   const l = text.toLowerCase()
   if (l.includes('error') || l.includes('fatal') || l.includes('panic') || l.includes('critical')) return 'log-error'
@@ -38,24 +13,14 @@ function classifyLog(text) {
 // ── AppDetail ─────────────────────────────────────────
 
 export function AppDetail({ stack, onClose }) {
-  const [sortOrder, setSortOrder] = useState(
-    () => localStorage.getItem('stackd:containerSort') || 'name-asc'
-  )
-  const sorted = sortContainers(stack.containers || [], sortOrder)
-  const [selectedContainer, setSelectedContainer] = useState(sorted[0]?.name ?? null)
+  const containers = stack.containers || []
+  const [selectedContainer, setSelectedContainer] = useState(containers[0]?.name ?? null)
 
   useEffect(() => {
-    const s = sortContainers(stack.containers || [], sortOrder)
-    setSelectedContainer(s[0]?.name ?? null)
+    setSelectedContainer((stack.containers || [])[0]?.name ?? null)
   }, [stack.name, stack.repoName])
 
-  const handleSortChange = (e) => {
-    const v = e.target.value
-    setSortOrder(v)
-    localStorage.setItem('stackd:containerSort', v)
-  }
-
-  const container = sorted.find(c => c.name === selectedContainer)
+  const container = containers.find(c => c.name === selectedContainer)
 
   return (
     <div class="app-detail">
@@ -101,37 +66,21 @@ export function AppDetail({ stack, onClose }) {
         )}
       </div>
 
-      {sorted.length > 0 ? (
+      {containers.length > 0 ? (
         <>
-          <div class="container-tabs-bar">
-            <div class="container-tabs" role="tablist" aria-label="Containers">
-              {sorted.map(c => (
-                <button
-                  key={c.name}
-                  role="tab"
-                  aria-selected={c.name === selectedContainer}
-                  class={`container-tab ${c.name === selectedContainer ? 'container-tab--active' : ''}`}
-                  onClick={() => setSelectedContainer(c.name)}
-                >
-                  <span class={`status-dot status-dot--${c.status}`} aria-hidden="true" />
-                  {c.name}
-                </button>
-              ))}
-            </div>
-            <div class="sort-control">
-              <label for="container-sort" class="sort-label">Sort</label>
-              <select
-                id="container-sort"
-                class="sort-select"
-                value={sortOrder}
-                onChange={handleSortChange}
-                aria-label="Sort containers"
+          <div class="container-tabs" role="tablist" aria-label="Containers">
+            {containers.map(c => (
+              <button
+                key={c.name}
+                role="tab"
+                aria-selected={c.name === selectedContainer}
+                class={`container-tab ${c.name === selectedContainer ? 'container-tab--active' : ''}`}
+                onClick={() => setSelectedContainer(c.name)}
               >
-                {SORT_OPTIONS.map(o => (
-                  <option key={o.key} value={o.key}>{o.label}</option>
-                ))}
-              </select>
-            </div>
+                <span class={`status-dot status-dot--${c.status}`} aria-hidden="true" />
+                {c.name}
+              </button>
+            ))}
           </div>
           {container && <ContainerDetail container={container} />}
         </>

--- a/internal/ui/src/components/AppGrid.css
+++ b/internal/ui/src/components/AppGrid.css
@@ -310,3 +310,53 @@
     font-size: 18px;
   }
 }
+
+/* ── Grid sort bar ───────────────────────────────── */
+.grid-sort-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 16px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.sort-label {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.sort-select {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 3px 22px 3px 8px;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%238b949e'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+  transition: border-color 0.1s, color 0.1s;
+}
+
+.sort-select:hover {
+  border-color: var(--accent-border);
+  color: var(--text-primary);
+}
+
+.sort-select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}

--- a/internal/ui/src/components/AppGrid.jsx
+++ b/internal/ui/src/components/AppGrid.jsx
@@ -1,5 +1,31 @@
+import { useState } from 'preact/hooks'
 import { formatRelative } from '../utils/time'
 import './AppGrid.css'
+
+const SORT_OPTIONS = [
+  { key: 'name-asc',     label: 'Name A→Z' },
+  { key: 'name-desc',    label: 'Name Z→A' },
+  { key: 'uptime-long',  label: 'Running longest' },
+  { key: 'uptime-short', label: 'Started recently' },
+]
+
+function sortStacks(stacks, order) {
+  const s = [...stacks]
+  switch (order) {
+    case 'name-asc':
+      return s.sort((a, b) => a.name.localeCompare(b.name))
+    case 'name-desc':
+      return s.sort((a, b) => b.name.localeCompare(a.name))
+    case 'uptime-long':
+      // oldest lastApply first = longest running
+      return s.sort((a, b) => new Date(a.lastApply || 0) - new Date(b.lastApply || 0))
+    case 'uptime-short':
+      // newest lastApply first = started most recently
+      return s.sort((a, b) => new Date(b.lastApply || 0) - new Date(a.lastApply || 0))
+    default:
+      return s
+  }
+}
 
 function deriveStackStatus(stack) {
   if (stack.status === 'error') return 'error'
@@ -12,6 +38,16 @@ function deriveStackStatus(stack) {
 }
 
 export function AppGrid({ repos, selectedStack, syncingRepos, syncStatus, onSelectStack, onForceSync }) {
+  const [sortOrder, setSortOrder] = useState(
+    () => localStorage.getItem('stackd:stackSort') || 'name-asc'
+  )
+
+  const handleSortChange = (e) => {
+    const v = e.target.value
+    setSortOrder(v)
+    localStorage.setItem('stackd:stackSort', v)
+  }
+
   if (!repos.length) {
     return (
       <div class="empty-state">
@@ -23,10 +59,25 @@ export function AppGrid({ repos, selectedStack, syncingRepos, syncStatus, onSele
 
   return (
     <div class="app-grid">
+      <div class="grid-sort-bar">
+        <label for="stack-sort" class="sort-label">Sort</label>
+        <select
+          id="stack-sort"
+          class="sort-select"
+          value={sortOrder}
+          onChange={handleSortChange}
+          aria-label="Sort stacks"
+        >
+          {SORT_OPTIONS.map(o => (
+            <option key={o.key} value={o.key}>{o.label}</option>
+          ))}
+        </select>
+      </div>
       {repos.map(repo => (
         <RepoGroup
           key={repo.name}
           repo={repo}
+          sortOrder={sortOrder}
           selectedStack={selectedStack}
           isSyncing={syncingRepos.has(repo.name)}
           repoSyncStatus={syncStatus?.[repo.name]}
@@ -38,11 +89,13 @@ export function AppGrid({ repos, selectedStack, syncingRepos, syncStatus, onSele
   )
 }
 
-function RepoGroup({ repo, selectedStack, isSyncing, repoSyncStatus, onSelectStack, onForceSync }) {
+function RepoGroup({ repo, sortOrder, selectedStack, isSyncing, repoSyncStatus, onSelectStack, onForceSync }) {
   const statusClass = repoSyncStatus?.state === 'success' ? 'repo-header--flash-ok'
     : repoSyncStatus?.state === 'rateLimit' ? 'repo-header--flash-warn'
     : repoSyncStatus?.state === 'error' ? 'repo-header--flash-err'
     : ''
+
+  const sortedStacks = sortStacks(repo.stacks || [], sortOrder)
 
   return (
     <div class="repo-group">
@@ -68,8 +121,8 @@ function RepoGroup({ repo, selectedStack, isSyncing, repoSyncStatus, onSelectSta
           <button
             class={`sync-btn ${isSyncing ? 'sync-btn--spinning' : ''}`}
             onClick={() => onForceSync(repo.name)}
-            aria-label={isSyncing ? `Syncing ${repo.name}…` : `Force git sync for ${repo.name}`}
-            title={isSyncing ? 'Syncing…' : 'Force git sync'}
+            aria-label={isSyncing ? `Syncing ${repo.name}…` : `Force sync ${repo.name}`}
+            title={isSyncing ? 'Syncing…' : 'Force sync'}
             disabled={isSyncing}
           >
             ↻
@@ -82,8 +135,8 @@ function RepoGroup({ repo, selectedStack, isSyncing, repoSyncStatus, onSelectSta
       )}
 
       <div class="stack-list">
-        {(repo.stacks || []).length > 0 ? (
-          repo.stacks.map(stack => (
+        {sortedStacks.length > 0 ? (
+          sortedStacks.map(stack => (
             <StackCard
               key={stack.name}
               stack={stack}
@@ -126,7 +179,13 @@ function StackCard({ stack, isSelected, onSelect }) {
     >
       <div class="stack-card__header">
         <span class="stack-card__name">{stack.name}</span>
-        <span class={`stack-badge stack-badge--${status}`} aria-hidden="true">{status}</span>
+        <span
+          class={`stack-badge stack-badge--${status}`}
+          aria-hidden="true"
+          title={status === 'degraded' ? 'Some containers are not running' : status === 'applying' ? 'Docker Compose is applying changes' : undefined}
+        >
+          {status}
+        </span>
       </div>
       <div class="stack-card__meta">
         <span class="container-count">{running}/{total} running</span>


### PR DESCRIPTION
Moves the sort control to the correct location (sidebar grid), fixes stacks jumping on every 5s refresh, clarifies sort labels, adds 'Synced ✓' feedback, and adds tooltips to degraded/applying badges.