### PR TITLE
fix: web guidelines audit pass 2 — aria, CLS, text-wrap

### DIFF
--- a/internal/ui/src/app.jsx
+++ b/internal/ui/src/app.jsx
@@ -64,7 +64,7 @@ export function App() {
     <div class="app-shell">
       <header class="app-header">
         <div class="app-header__brand">
-          <img src="/logo.svg" alt="stackd" class="app-logo" />
+          <img src="/logo.svg" alt="stackd" class="app-logo" width="97" height="36" />
         </div>
         <div class="app-header__meta">
           {infisical?.enabled && (
@@ -74,8 +74,8 @@ export function App() {
       </header>
 
       {error && (
-        <div class="error-banner">
-          <span>⚠ Could not reach API: {error}</span>
+        <div class="error-banner" role="alert">
+          <span><span aria-hidden="true">⚠</span> Could not reach API: {error}</span>
           <button onClick={fetchStatus}>Retry</button>
         </div>
       )}

--- a/internal/ui/src/components/AppDetail.css
+++ b/internal/ui/src/components/AppDetail.css
@@ -47,6 +47,7 @@
   font-size: 16px;
   font-weight: 700;
   color: var(--text-primary);
+  text-wrap: balance;
 }
 
 /* P0-3 fix: aria-label="Close" added in JSX         */

--- a/internal/ui/src/components/AppDetail.jsx
+++ b/internal/ui/src/components/AppDetail.jsx
@@ -164,7 +164,7 @@ function LogStream({ containerName }) {
       {streamEnded && (
         <div class="stream-banner" role="status" aria-live="assertive">
           <span>Stream ended</span>
-          <button class="stream-reconnect" onClick={startStream}>↻ Reconnect</button>
+          <button class="stream-reconnect" onClick={startStream}><span aria-hidden="true">↻</span> Reconnect</button>
         </div>
       )}
       <div class="logs-content" role="log" aria-live="polite" aria-label={`Logs for ${containerName}`}>

--- a/internal/ui/src/components/AppGrid.jsx
+++ b/internal/ui/src/components/AppGrid.jsx
@@ -63,6 +63,7 @@ export function AppGrid({ repos, selectedStack, syncingRepos, syncStatus, onSele
         <label for="stack-sort" class="sort-label">Sort</label>
         <select
           id="stack-sort"
+          name="stack-sort"
           class="sort-select"
           value={sortOrder}
           onChange={handleSortChange}
@@ -125,7 +126,7 @@ function RepoGroup({ repo, sortOrder, selectedStack, isSyncing, repoSyncStatus, 
             title={isSyncing ? 'Syncing…' : 'Force sync'}
             disabled={isSyncing}
           >
-            ↻
+            <span aria-hidden="true">↻</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Web Interface Guidelines — Audit Pass 2

Fixes all findings from the second compliance run.

| File | Issue | Fix |
|------|-------|-----|
| `app.jsx:67` | `<img>` missing `width`/`height` attrs → CLS risk | Added `width="97" height="36"` (from viewBox 2557×952) |
| `app.jsx:77` | `.error-banner` missing `role="alert"` | Added — screen readers now announce API errors immediately |
| `app.jsx:78` | `⚠` decorative glyph not hidden from AT | `<span aria-hidden="true">⚠</span>` |
| `AppGrid.jsx:64` | `<select>` missing `name` attribute | Added `name="stack-sort"` |
| `AppGrid.jsx:128` | `↻` inside aria-labelled button not hidden | `<span aria-hidden="true">↻</span>` |
| `AppDetail.jsx:167` | `↻` in stream-reconnect button text not hidden | `<span aria-hidden="true">↻</span> Reconnect` |
| `AppDetail.css` | `.detail-stack-name` missing `text-wrap: balance` | Added — prevents orphaned words in long stack names |

### Passing (no changes needed)
- `color-scheme: dark` on `<html>` ✓
- `-webkit-tap-highlight-color` ✓
- `prefers-reduced-motion` guards on all animations ✓
- No `transition: all` anywhere ✓
- No `outline: none` without `:focus-visible` ✓
- `touch-action: manipulation` on all interactive elements ✓
- `overscroll-behavior: contain` on logs ✓
- `font-variant-numeric: tabular-nums` on timestamps ✓
- `env(safe-area-inset-bottom)` on mobile close bar ✓
- Google Fonts: `preconnect` + `display=swap` already best practice ✓