### PR TITLE
fix: sort bar in repo group + mobile detail full-screen overlay

### DIFF
--- a/internal/ui/src/app.css
+++ b/internal/ui/src/app.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
+  height: 100dvh; /* accounts for iOS Safari toolbar */
   background: var(--bg-primary);
 }
 
@@ -89,6 +90,7 @@
   display: flex;
   flex: 1;
   overflow: hidden;
+  position: relative; /* anchor for mobile overlay */
 }
 
 .grid-panel {
@@ -115,13 +117,21 @@
   }
   .grid-panel {
     width: 100%;
-    max-height: 45vh;
+    flex: 1;
+    min-height: 0;
+    max-height: none;
     border-right: none;
-    border-bottom: 1px solid var(--border-color);
     overflow-y: auto;
   }
+  /* Detail panel overlays the full container on mobile */
   .detail-panel {
-    flex: 1;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 10;
+    flex: none;
     min-height: 0;
   }
 }

--- a/internal/ui/src/components/AppGrid.css
+++ b/internal/ui/src/components/AppGrid.css
@@ -324,9 +324,6 @@
   padding: 7px 16px;
   border-bottom: 1px solid var(--border-color);
   background: var(--bg-secondary);
-  position: sticky;
-  top: 0;
-  z-index: 2;
 }
 
 .sort-label {

--- a/internal/ui/src/components/AppGrid.jsx
+++ b/internal/ui/src/components/AppGrid.jsx
@@ -59,26 +59,12 @@ export function AppGrid({ repos, selectedStack, syncingRepos, syncStatus, onSele
 
   return (
     <div class="app-grid">
-      <div class="grid-sort-bar">
-        <label for="stack-sort" class="sort-label">Sort</label>
-        <select
-          id="stack-sort"
-          name="stack-sort"
-          class="sort-select"
-          value={sortOrder}
-          onChange={handleSortChange}
-          aria-label="Sort stacks"
-        >
-          {SORT_OPTIONS.map(o => (
-            <option key={o.key} value={o.key}>{o.label}</option>
-          ))}
-        </select>
-      </div>
       {repos.map(repo => (
         <RepoGroup
           key={repo.name}
           repo={repo}
           sortOrder={sortOrder}
+          onSortChange={handleSortChange}
           selectedStack={selectedStack}
           isSyncing={syncingRepos.has(repo.name)}
           repoSyncStatus={syncStatus?.[repo.name]}
@@ -90,7 +76,7 @@ export function AppGrid({ repos, selectedStack, syncingRepos, syncStatus, onSele
   )
 }
 
-function RepoGroup({ repo, sortOrder, selectedStack, isSyncing, repoSyncStatus, onSelectStack, onForceSync }) {
+function RepoGroup({ repo, sortOrder, onSortChange, selectedStack, isSyncing, repoSyncStatus, onSelectStack, onForceSync }) {
   const statusClass = repoSyncStatus?.state === 'success' ? 'repo-header--flash-ok'
     : repoSyncStatus?.state === 'rateLimit' ? 'repo-header--flash-warn'
     : repoSyncStatus?.state === 'error' ? 'repo-header--flash-err'
@@ -134,6 +120,22 @@ function RepoGroup({ repo, sortOrder, selectedStack, isSyncing, repoSyncStatus, 
       {repo.lastError && (
         <div class="repo-error" role="alert">{repo.lastError}</div>
       )}
+
+      <div class="grid-sort-bar">
+        <label for={`stack-sort-${repo.name}`} class="sort-label">Sort</label>
+        <select
+          id={`stack-sort-${repo.name}`}
+          name="stack-sort"
+          class="sort-select"
+          value={sortOrder}
+          onChange={onSortChange}
+          aria-label="Sort stacks"
+        >
+          {SORT_OPTIONS.map(o => (
+            <option key={o.key} value={o.key}>{o.label}</option>
+          ))}
+        </select>
+      </div>
 
       <div class="stack-list">
         {sortedStacks.length > 0 ? (


### PR DESCRIPTION
Two fixes in one branch:

## 1. Sort bar moved into RepoGroup
Sort control now renders inside each `.repo-group`, between the repo header and the stack list (matching the expected DOM structure). Removed `position: sticky` — no longer needed since the repo header already handles that.

## 2. Mobile detail panel — full-screen overlay
- `height: 100dvh` on `.app-shell` → fixes iOS Safari toolbar cutting off bottom content
- `.app-container`: `position: relative` to anchor the overlay
- On mobile, `.detail-panel` is now `position: absolute; inset: 0; z-index: 10` → full-screen overlay over the grid; logs/env/info tabs have the full viewport to work with
- `.grid-panel` fills full height (`flex: 1`) when detail is closed → removes the old `45vh` cap that left dead space