### PR TITLE
fix: strip dated borders — use background elevation instead

### DIFF
--- a/internal/ui/src/components/AppDetail.css
+++ b/internal/ui/src/components/AppDetail.css
@@ -55,7 +55,7 @@
 /* P1-2 fix: focus-visible added                     */
 .close-btn {
   background: transparent;
-  border: 1px solid var(--border-color);
+  border: none;
   color: var(--text-secondary);
   width: 28px;
   height: 28px;
@@ -66,12 +66,10 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  /* Specific properties only */
-  transition: background 0.1s, border-color 0.1s, color 0.1s;
+  transition: background 0.1s, color 0.1s;
 }
 
 .close-btn:hover {
-  border-color: var(--status-stopped);
   color: var(--status-stopped);
   background: rgba(248, 81, 73, 0.08);
 }
@@ -94,7 +92,6 @@
   display: flex;
   flex-direction: column;
   padding: 10px 20px;
-  border-right: 1px solid var(--border-color);
   min-width: 0;
 }
 
@@ -169,7 +166,6 @@
 
 .container-tab--active {
   background: var(--bg-tertiary);
-  border-color: var(--border-color);
   color: var(--text-primary);
 }
 
@@ -335,9 +331,7 @@
   padding: 5px 10px;
   border-radius: var(--radius-sm);
   background: var(--bg-secondary);
-  border: 1px solid var(--border-subtle);
   overflow: hidden;
-  /* Specific transition */
   transition: background 0.1s;
 }
 
@@ -387,7 +381,6 @@
   gap: 12px;
   padding: 8px 12px;
   background: var(--bg-secondary);
-  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
 }
 
@@ -497,19 +490,18 @@
     width: 100%;
     min-height: 44px;
     background: var(--bg-tertiary);
-    border: 1px solid var(--border-color);
+    border: none;
     border-radius: var(--radius-md);
     color: var(--text-primary);
     font-family: var(--font-ui);
     font-size: 14px;
     font-weight: 500;
     cursor: pointer;
-    transition: background 0.1s, border-color 0.1s;
+    transition: background 0.1s;
   }
 
   .mobile-close-btn:hover {
     background: var(--bg-hover);
-    border-color: var(--accent-border);
   }
 
   .mobile-close-btn:focus-visible {

--- a/internal/ui/src/components/AppGrid.css
+++ b/internal/ui/src/components/AppGrid.css
@@ -125,7 +125,7 @@
 /* P1-2 fix: focus-visible added                      */
 .sync-btn {
   background: transparent;
-  border: 1px solid var(--border-color);
+  border: none;
   color: var(--text-secondary);
   width: 28px;
   height: 28px;
@@ -135,7 +135,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.1s, border-color 0.1s, color 0.1s;
+  transition: background 0.1s, color 0.1s;
   flex-shrink: 0;
   line-height: 1;
   touch-action: manipulation;
@@ -189,7 +189,7 @@
   text-align: left;
   padding: 10px 12px;
   border-radius: var(--radius-md);
-  border: 1px solid var(--border-color);
+  border: none;
   border-left: 2px solid transparent;
   cursor: pointer;
   transition: background 0.1s, border-left-color 0.1s;
@@ -341,7 +341,7 @@
   font-size: 12px;
   color: var(--text-secondary);
   background: var(--bg-tertiary);
-  border: 1px solid var(--border-color);
+  border: 1px solid transparent;
   border-radius: var(--radius-sm);
   padding: 3px 22px 3px 8px;
   cursor: pointer;
@@ -354,7 +354,7 @@
 }
 
 .sort-select:hover {
-  border-color: var(--accent-border);
+  border-color: var(--border-subtle);
   color: var(--text-primary);
 }
 


### PR DESCRIPTION
Modern dark UIs (Linear, Vercel, GitHub) use background colour hierarchy rather than boxing everything in borders. This removes the dated dashboard look.

**Removed:**
- `stack-card` outer border → background contrast carries it
- `sync-btn` border → ghost icon button, no box
- `close-btn` border → same
- `sort-select` border → transparent, subtle on hover only
- `meta-item` `border-right` → no more table-cell grid look
- `container-tab--active` border → background only
- `env-item` border → `bg-secondary` on `bg-primary` is enough
- `info-row` border → same
- `mobile-close-btn` border → bg-tertiary defines the button

**Kept (structural/functional):**
Section `border-bottom` dividers, grid-panel `border-right`, repo-header accent `border-left`, info-tab underline, log-line error/warn `border-left`, badge rgba borders, flash classes, banner borders