### PR TITLE
ci: remove pull_request trigger — single build on push to master

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,8 +12,6 @@ on:
       - "go.mod"
       - "go.sum"
     tags: ["v*.*.*"]
-  pull_request:
-    branches: ["master"]
   workflow_dispatch:
 
 permissions:
@@ -37,7 +35,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install cosign
-        if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
         with:
           cosign-release: "v2.2.4"
@@ -46,7 +43,6 @@ jobs:
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -60,7 +56,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
@@ -71,14 +66,14 @@ jobs:
         with:
           context: .
           file: ./dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'schedule' }}
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}


### PR DESCRIPTION
## Problem
Every PR merge triggered two Docker builds:
1. The `pull_request` event on the PR itself (build only, no push)
2. The `push` to master when merged (build + push + sign)

The `pull_request` trigger also had **no `paths` filter**, so it fired on every single PR regardless of whether any code changed.

## Fix
- Removed `pull_request` trigger entirely
- Removed all `if: github.event_name != 'pull_request'` guards (always true now)
- Removed dead `type=ref,event=pr` metadata tag
- Sign step now skips on `schedule` only (nightly rebuilds have no tag to sign)

## Triggers after this change
| Event | Builds | Pushes to registry |
|-------|--------|-------------------|
| Push to master (code changed) | ✓ | ✓ |
| Version tag `v*.*.*` | ✓ | ✓ |
| Nightly schedule | ✓ | ✓ |
| `workflow_dispatch` | ✓ | ✓ |
| PR opened/updated | — | — |