### PR TITLE
ci: add Go vet/build check workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["master"]
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+  push:
+    branches: ["master"]
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: vet & build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: go mod tidy check
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go build
+        run: go build ./...

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/docker/docker v28.5.2+incompatible
+	github.com/docker/go-connections v0.6.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -14,7 +15,6 @@ require (
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect


### PR DESCRIPTION
Adds a fast CI check that runs on every PR touching Go files (~30s).

**Jobs:**
- `go mod tidy` + `git diff --exit-code` — fails if go.sum is stale
- `go vet ./...` — catches suspicious constructs, unreachable code, etc.
- `go build ./...` — catches compile errors before they hit master

**Triggers:** `pull_request` and `push` to master, gated on `**.go / go.mod / go.sum` path filter so it doesn't fire on pure UI or docs changes.

When tests are added later, a single `go test ./...` line drops in here.