### PR TITLE
ci: build frontend before go vet/build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,17 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: internal/ui/package-lock.json
+
+      - name: Build frontend
+        working-directory: internal/ui
+        run: npm ci && npm run build
+
       - name: go mod tidy check
         run: |
           go mod tidy


### PR DESCRIPTION
Fix for the CI failure: `internal/ui/ui.go` uses `//go:embed dist` — `dist/` is not committed so `go vet` fails with _pattern dist: no matching files found_.\n\nAdds Node 20 + `npm ci` + `vite build` before the Go steps so the embed target exists.