### PR TITLE
fix: UI visual refresh — strip borders, lift type, align sort

### DIFF
--- a/internal/ui/src/components/AppDetail.css
+++ b/internal/ui/src/components/AppDetail.css
@@ -11,8 +11,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 20px;
-  border-bottom: 1px solid var(--border-color);
+  padding: 16px 20px 12px;
   background: var(--bg-secondary);
   flex-shrink: 0;
 }
@@ -44,7 +43,7 @@
 .detail-stack-name {
   margin: 0;
   font-family: var(--font-ui);
-  font-size: 16px;
+  font-size: 18px;
   font-weight: 700;
   color: var(--text-primary);
   text-wrap: balance;
@@ -84,7 +83,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0;
-  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 4px;
   flex-shrink: 0;
 }
 

--- a/internal/ui/src/components/AppGrid.css
+++ b/internal/ui/src/components/AppGrid.css
@@ -23,7 +23,7 @@
 
 /* ── Repo group ──────────────────────────────────── */
 .repo-group {
-  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 8px;
 }
 
 /* P1-15 fix: left indigo accent border, padding adjusted for 3px border */
@@ -57,7 +57,7 @@
 .repo-name {
   font-family: var(--font-ui);
   font-weight: 700;
-  font-size: 13px;
+  font-size: 15px;
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -68,11 +68,7 @@
 .repo-sha {
   font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--text-secondary);
-  background: var(--bg-primary);
-  padding: 1px 6px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border-color);
+  color: var(--text-muted);
   letter-spacing: 0.3px;
 }
 
@@ -229,7 +225,7 @@
 /* font-weight 600, var(--font-ui) */
 .stack-card__name {
   font-family: var(--font-ui);
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--text-primary);
   white-space: nowrap;
@@ -267,13 +263,13 @@
   white-space: nowrap;
 }
 
-.stack-badge--running  { background: rgba(63,  185, 80,  0.15); color: var(--status-running);  border: 1px solid rgba(63,  185, 80,  0.3);  }
-.stack-badge--ok       { background: rgba(63,  185, 80,  0.15); color: var(--status-ok);       border: 1px solid rgba(63,  185, 80,  0.3);  }
-.stack-badge--stopped  { background: rgba(248, 81,  73,  0.12); color: var(--status-stopped);  border: 1px solid rgba(248, 81,  73,  0.25); }
-.stack-badge--degraded { background: rgba(210, 153, 34,  0.12); color: var(--status-degraded); border: 1px solid rgba(210, 153, 34,  0.25); }
-.stack-badge--error    { background: rgba(248, 81,  73,  0.12); color: var(--status-error);    border: 1px solid rgba(248, 81,  73,  0.25); }
-.stack-badge--applying { background: rgba(88,  166, 255, 0.12); color: var(--status-applying); border: 1px solid rgba(88,  166, 255, 0.25); }
-.stack-badge--unknown  { background: rgba(72,  79,  88,  0.2);  color: var(--status-unknown);  border: 1px solid rgba(72,  79,  88,  0.3);  }
+.stack-badge--running  { background: rgba(63,  185, 80,  0.15); color: var(--status-running);  }
+.stack-badge--ok       { background: rgba(63,  185, 80,  0.15); color: var(--status-ok);       }
+.stack-badge--stopped  { background: rgba(248, 81,  73,  0.12); color: var(--status-stopped);  }
+.stack-badge--degraded { background: rgba(210, 153, 34,  0.12); color: var(--status-degraded); }
+.stack-badge--error    { background: rgba(248, 81,  73,  0.12); color: var(--status-error);    }
+.stack-badge--applying { background: rgba(88,  166, 255, 0.12); color: var(--status-applying); }
+.stack-badge--unknown  { background: rgba(72,  79,  88,  0.2);  color: var(--status-unknown);  }
 
 /* ── Sync feedback ───────────────────────────────── */
 .sync-feedback {
@@ -287,19 +283,16 @@
 .sync-feedback--success {
   color: var(--status-running);
   background: rgba(63, 185, 80, 0.1);
-  border: 1px solid rgba(63, 185, 80, 0.25);
 }
 
 .sync-feedback--rateLimit {
   color: var(--status-degraded);
   background: rgba(210, 153, 34, 0.1);
-  border: 1px solid rgba(210, 153, 34, 0.25);
 }
 
 .sync-feedback--error {
   color: var(--status-stopped);
   background: rgba(248, 81, 73, 0.1);
-  border: 1px solid rgba(248, 81, 73, 0.25);
 }
 
 /* Flash the repo header border on sync result */
@@ -321,8 +314,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 7px 16px;
-  border-bottom: 1px solid var(--border-color);
+  padding: 6px 16px 10px;
   background: var(--bg-secondary);
 }
 

--- a/internal/ui/src/components/AppGrid.css
+++ b/internal/ui/src/components/AppGrid.css
@@ -313,7 +313,7 @@
 .grid-sort-bar {
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: space-between;
   padding: 6px 16px 10px;
   background: var(--bg-secondary);
 }


### PR DESCRIPTION
Two-part cleanup:

**Border reduction (final pass):**
- `repo-group` border-bottom → spacing
- `grid-sort-bar` border-bottom → removed
- `detail-header` border-bottom → padding
- `stack-meta-grid` border-bottom → padding
- `repo-sha` pill (background + border) → bare muted monospace
- Status badge `1px rgba` borders → tint alone is sufficient
- Sync feedback `1px rgba` borders → same

**Typography:**
- repo-name: 13px → 15px
- stack-card__name: 13px → 14px
- detail-stack-name: 16px → 18px

**Sort bar layout:**
- `justify-content: space-between` — label left, dropdown right, matching the repo header pattern (name+sha ··· sync time+btn)