### PR TITLE
feat: start/stop/restart controls in container detail panel

### DIFF
--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -184,7 +184,29 @@ func formatPorts(portMap nat.PortMap) []string {
 	return ports
 }
 
-// ListStackContainers returns the names of all containers belonging to the
+// StartContainer starts a stopped container by name.
+func (c *Client) StartContainer(ctx context.Context, name string) error {
+	if err := c.cli.ContainerStart(ctx, name, dockertypes.StartOptions{}); err != nil {
+		return fmt.Errorf("StartContainer %s: %w", name, err)
+	}
+	return nil
+}
+
+// StopContainer stops a running container by name.
+func (c *Client) StopContainer(ctx context.Context, name string) error {
+	if err := c.cli.ContainerStop(ctx, name, dockertypes.StopOptions{}); err != nil {
+		return fmt.Errorf("StopContainer %s: %w", name, err)
+	}
+	return nil
+}
+
+// RestartContainer restarts a container by name.
+func (c *Client) RestartContainer(ctx context.Context, name string) error {
+	if err := c.cli.ContainerRestart(ctx, name, dockertypes.StopOptions{}); err != nil {
+		return fmt.Errorf("RestartContainer %s: %w", name, err)
+	}
+	return nil
+}
 // compose project whose directory is stackDir (matched by project label).
 func (c *Client) ListStackContainers(ctx context.Context, stackDir string) ([]string, error) {
 	// Compose derives the project name from the directory name, lowercased.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -127,6 +127,17 @@ func (s *Server) registerRoutes() {
 	// GET /api/logs/{container} — SSE stream of Docker logs
 	s.mux.HandleFunc("GET /api/logs/{container}", s.handleLogs)
 
+	// POST /api/containers/{container}/start|stop|restart — lifecycle control
+	s.mux.HandleFunc("POST /api/containers/{container}/start", func(w http.ResponseWriter, r *http.Request) {
+		s.handleContainerAction(w, r, "start")
+	})
+	s.mux.HandleFunc("POST /api/containers/{container}/stop", func(w http.ResponseWriter, r *http.Request) {
+		s.handleContainerAction(w, r, "stop")
+	})
+	s.mux.HandleFunc("POST /api/containers/{container}/restart", func(w http.ResponseWriter, r *http.Request) {
+		s.handleContainerAction(w, r, "restart")
+	})
+
 	// GET /healthz — liveness probe (always 200)
 	s.mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -278,6 +289,79 @@ func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.docker.StreamLogs(ctx, containerName, sw); err != nil {
 		fmt.Fprintf(sw, "error: %v", err)
+	}
+}
+
+// handleContainerAction dispatches start/stop/restart for a single container.
+func (s *Server) handleContainerAction(w http.ResponseWriter, r *http.Request, action string) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.docker == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]string{"error": "docker unavailable"})
+		return
+	}
+	name := r.PathValue("container")
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	var err error
+	switch action {
+	case "start":
+		err = s.docker.StartContainer(ctx, name)
+	case "stop":
+		err = s.docker.StopContainer(ctx, name)
+	case "restart":
+		err = s.docker.RestartContainer(ctx, name)
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "unknown action"})
+		return
+	}
+	if err != nil {
+		slog.Error("container action failed", "action", action, "container", name, "err", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	slog.Info("container action succeeded", "action", action, "container", name)
+	// Refresh state asynchronously so the next /api/status poll reflects reality.
+	go s.refreshContainerState(name)
+	json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+}
+
+// refreshContainerState re-fetches container details for every stack containing
+// the named container and updates the store.
+func (s *Server) refreshContainerState(containerName string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	for _, st := range s.store.GetAllStacks() {
+		dockerDetails, err := s.docker.ListStackContainerDetails(ctx, st.StackDir)
+		if err != nil {
+			continue
+		}
+		found := false
+		for _, d := range dockerDetails {
+			if d.Name == containerName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			continue
+		}
+		stateDetails := make([]state.ContainerDetail, 0, len(dockerDetails))
+		for _, d := range dockerDetails {
+			stateDetails = append(stateDetails, state.ContainerDetail{
+				ID:        d.ID,
+				Name:      d.Name,
+				Image:     d.Image,
+				Status:    d.Status,
+				StartedAt: d.StartedAt,
+				Env:       d.Env,
+				Ports:     d.Ports,
+			})
+		}
+		s.store.UpdateStackContainers(st.RepoName, st.Name, stateDetails)
 	}
 }
 

--- a/internal/ui/src/app.jsx
+++ b/internal/ui/src/app.jsx
@@ -29,6 +29,18 @@ export function App() {
     return () => clearInterval(interval)
   }, [])
 
+  // Keep selectedStack live — sync it from repos on every poll so container
+  // status reflects reality immediately after a start/stop/restart action.
+  useEffect(() => {
+    if (!selectedStack) return
+    for (const repo of repos) {
+      if (repo.name !== selectedStack.repoName) continue
+      const fresh = (repo.stacks || []).find(s => s.name === selectedStack.name)
+      if (fresh) setSelectedStack({ ...fresh, repoName: repo.name })
+      break
+    }
+  }, [repos])
+
   const clearSyncing = (repoName) => {
     setSyncingRepos(prev => {
       const s = new Set(prev)
@@ -96,6 +108,7 @@ export function App() {
             <AppDetail
               stack={selectedStack}
               onClose={() => setSelectedStack(null)}
+              onRefresh={fetchStatus}
             />
           </div>
         )}

--- a/internal/ui/src/components/AppDetail.css
+++ b/internal/ui/src/components/AppDetail.css
@@ -206,6 +206,73 @@
   overflow: hidden;
 }
 
+/* ── Container action bar ────────────────────────── */
+.container-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 16px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.container-actions__btns {
+  display: flex;
+  gap: 4px;
+}
+
+.ctrl-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 12px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+  touch-action: manipulation;
+  min-height: 28px;
+}
+
+.ctrl-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.ctrl-btn:not(:disabled):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.ctrl-btn--start:not(:disabled):hover  { background: rgba(63, 185, 80, 0.1);   color: var(--status-running);  }
+.ctrl-btn--stop:not(:disabled):hover   { background: rgba(248, 81, 73, 0.1);   color: var(--status-stopped);  }
+.ctrl-btn--restart:not(:disabled):hover { background: rgba(88, 166, 255, 0.1); color: var(--status-applying); }
+
+.ctrl-spinner {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+.ctrl-feedback {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  animation: fadeIn 0.15s ease-out;
+}
+
+.ctrl-feedback--ok  { color: var(--status-running); }
+.ctrl-feedback--err { color: var(--status-stopped); }
+
 /* ── Info tabs (Logs / Env / Info) ───────────────── */
 /* P1-1 fix: specific transition; P1-2 fix: focus-visible */
 .info-tabs {

--- a/internal/ui/src/components/AppDetail.jsx
+++ b/internal/ui/src/components/AppDetail.jsx
@@ -12,7 +12,7 @@ function classifyLog(text) {
 
 // ── AppDetail ─────────────────────────────────────────
 
-export function AppDetail({ stack, onClose }) {
+export function AppDetail({ stack, onClose, onRefresh }) {
   const containers = stack.containers || []
   const [selectedContainer, setSelectedContainer] = useState(containers[0]?.name ?? null)
 
@@ -82,7 +82,7 @@ export function AppDetail({ stack, onClose }) {
               </button>
             ))}
           </div>
-          {container && <ContainerDetail container={container} />}
+          {container && <ContainerDetail container={container} onRefresh={onRefresh} />}
         </>
       ) : (
         <div class="empty-state-inline">
@@ -102,11 +102,67 @@ export function AppDetail({ stack, onClose }) {
 
 // ── ContainerDetail ───────────────────────────────────
 
-function ContainerDetail({ container }) {
+function ContainerDetail({ container, onRefresh }) {
   const [tab, setTab] = useState('logs')
+  const [actionState, setActionState] = useState(null) // 'loading'|{ok}|{err}
+  const [activeAction, setActiveAction] = useState(null)
+
+  const isRunning = container.status === 'running'
+  const isStopped = container.status === 'stopped' || container.status === 'exited'
+
+  const doAction = async (action) => {
+    setActiveAction(action)
+    setActionState('loading')
+    try {
+      const res = await fetch(`/api/containers/${encodeURIComponent(container.name)}/${action}`, { method: 'POST' })
+      const body = await res.json()
+      if (!res.ok || body.error) throw new Error(body.error || `HTTP ${res.status}`)
+      setActionState({ ok: true })
+      onRefresh?.()
+    } catch (e) {
+      setActionState({ err: e.message })
+    } finally {
+      setTimeout(() => { setActionState(null); setActiveAction(null) }, 2000)
+    }
+  }
+
+  const loading = actionState === 'loading'
 
   return (
     <div class="container-detail">
+      <div class="container-actions">
+        <div class="container-actions__btns">
+          <button
+            class={`ctrl-btn ctrl-btn--start ${activeAction === 'start' && loading ? 'ctrl-btn--loading' : ''}`}
+            onClick={() => doAction('start')}
+            disabled={loading || isRunning}
+            aria-label="Start container"
+            touch-action="manipulation"
+          >
+            {activeAction === 'start' && loading ? <span class="ctrl-spinner" aria-hidden="true" /> : '▶'} Start
+          </button>
+          <button
+            class={`ctrl-btn ctrl-btn--stop ${activeAction === 'stop' && loading ? 'ctrl-btn--loading' : ''}`}
+            onClick={() => doAction('stop')}
+            disabled={loading || isStopped}
+            aria-label="Stop container"
+            touch-action="manipulation"
+          >
+            {activeAction === 'stop' && loading ? <span class="ctrl-spinner" aria-hidden="true" /> : '■'} Stop
+          </button>
+          <button
+            class={`ctrl-btn ctrl-btn--restart ${activeAction === 'restart' && loading ? 'ctrl-btn--loading' : ''}`}
+            onClick={() => doAction('restart')}
+            disabled={loading}
+            aria-label="Restart container"
+            touch-action="manipulation"
+          >
+            {activeAction === 'restart' && loading ? <span class="ctrl-spinner" aria-hidden="true" /> : '↻'} Restart
+          </button>
+        </div>
+        {actionState?.ok && <span class="ctrl-feedback ctrl-feedback--ok">Done ✓</span>}
+        {actionState?.err && <span class="ctrl-feedback ctrl-feedback--err">{actionState.err}</span>}
+      </div>
       <div class="info-tabs" role="tablist" aria-label="Container detail sections">
         {[['logs', 'Logs'], ['env', 'Env'], ['info', 'Info']].map(([t, label]) => (
           <button


### PR DESCRIPTION
Adds lifecycle control buttons to the ContainerDetail section of the dashboard.

## What's new

**▶ Start / ■ Stop / ↻ Restart** buttons appear above the Logs/Env/Info tabs for each container.

### Context-aware states
| Container status | Start | Stop | Restart |
|---|---|---|---|
| `running` | disabled | enabled | enabled |
| `stopped` / `exited` | enabled | disabled | enabled |
| Action in flight | all disabled | all disabled | all disabled |

### Feedback
- Active button shows a CSS spinner while the request is in flight
- 2s inline "Done ✓" or error message on completion
- `onRefresh` fires immediately on success — no waiting for the 5s poll

## Backend
- `docker/client.go`: `StartContainer`, `StopContainer`, `RestartContainer` SDK wrappers
- `server/server.go`: `POST /api/containers/{name}/start|stop|restart` with 30s timeout; async `refreshContainerState` goroutine updates the store

## Frontend
- `app.jsx`: `selectedStack` synced live from `repos` on every poll (fixes stale snapshot after action)
- `AppDetail.jsx`: action bar with spinner + inline feedback
- `AppDetail.css`: borderless button style matching project conventions