### PR TITLE
feat: settings UI — repos, SSH keys, and general config management

### DIFF
--- a/internal/ui/src/components/Settings.css
+++ b/internal/ui/src/components/Settings.css
@@ -486,6 +486,48 @@
   line-height: 1.5;
 }
 
+/* ── Inline form (replaces modal for add/edit repo) ────── */
+.inline-form {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+.inline-form__title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 16px;
+}
+
+/* ── Confirm row (inline delete confirmation) ──────────── */
+.confirm-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+/* ── Small button variant ──────────────────────────────── */
+.btn-sm {
+  padding: 3px 10px;
+  font-size: 12px;
+}
+
+.btn-danger-confirm {
+  color: var(--status-stopped);
+  border-color: rgba(248, 81, 73, 0.4);
+}
+
+.btn-danger-confirm:hover {
+  background: rgba(248, 81, 73, 0.1);
+  color: var(--status-stopped);
+}
+
 /* ── Modal ─────────────────────────────────────────────── */
 .modal-overlay {
   position: fixed;

--- a/internal/ui/src/components/Settings.jsx
+++ b/internal/ui/src/components/Settings.jsx
@@ -3,98 +3,7 @@ import './Settings.css'
 
 // ---- Repos tab -----------------------------------------------------------
 
-function ReposTab({ sshKeys }) {
-  const [repos, setRepos] = useState([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(null)
-  const [modal, setModal] = useState(null) // null | 'add' | repo object
-
-  const loadRepos = () => {
-    setLoading(true)
-    fetch('/api/settings/repos')
-      .then(r => r.json())
-      .then(data => { setRepos(data); setLoading(false) })
-      .catch(e => { setError(e.message); setLoading(false) })
-  }
-
-  useEffect(loadRepos, [])
-
-  const deleteRepo = async (id, name) => {
-    if (!confirm(`Delete "${name}"? Active syncs will stop.`)) return
-    await fetch(`/api/settings/repos/${id}`, { method: 'DELETE' })
-    loadRepos()
-  }
-
-  return (
-    <div class="settings-tab">
-      <div class="settings-tab__header">
-        <h2>Repositories</h2>
-        <button class="btn-primary" onClick={() => setModal('add')}>+ Add repo</button>
-      </div>
-      {error && <p class="settings-error">{error}</p>}
-      {loading ? (
-        <p class="settings-loading">Loading…</p>
-      ) : repos.length === 0 ? (
-        <div class="settings-empty">
-          <p>No repos configured.</p>
-          <p>Add a repository to start syncing Docker Compose stacks.</p>
-        </div>
-      ) : (
-        <div class="table-wrap">
-          <table class="settings-table">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>URL</th>
-                <th>Branch</th>
-                <th>Auth</th>
-                <th>Stacks dir</th>
-                <th>Interval</th>
-                <th>Status</th>
-                <th aria-label="Actions"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {repos.map(repo => (
-                <tr key={repo.id}>
-                  <td class="td-name">{repo.name}</td>
-                  <td class="td-url">{repo.url}</td>
-                  <td>{repo.branch}</td>
-                  <td>{repo.authType || 'none'}</td>
-                  <td class="td-mono">{repo.stacksDir || '.'}</td>
-                  <td>{repo.syncInterval}s</td>
-                  <td>
-                    <span class={`status-pill ${repo.enabled ? 'status-pill--on' : 'status-pill--off'}`}>
-                      {repo.enabled ? 'enabled' : 'disabled'}
-                    </span>
-                  </td>
-                  <td class="td-actions">
-                    <button class="btn-icon" onClick={() => setModal(repo)} aria-label="Edit repo">
-                      <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M11.013 1.427a1.75 1.75 0 0 1 2.474 0l1.086 1.086a1.75 1.75 0 0 1 0 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 0 1-.927-.928l.929-3.25c.081-.286.235-.547.445-.758l8.61-8.61z"/></svg>
-                    </button>
-                    <button class="btn-icon btn-icon--danger" onClick={() => deleteRepo(repo.id, repo.name)} aria-label="Delete repo">
-                      <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M11 1.75V3h2.25a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1 0-1.5H5V1.75C5 .784 5.784 0 6.75 0h2.5C10.216 0 11 .784 11 1.75zM6.5 1.75V3h3V1.75a.25.25 0 0 0-.25-.25h-2.5a.25.25 0 0 0-.25.25zM4.997 6.5a.75.75 0 1 0-1.5.006l.139 9.25a.75.75 0 0 0 1.5-.005zm5.006.006a.75.75 0 0 0-1.5-.006l-.139 9.25a.75.75 0 0 0 1.5.005z"/></svg>
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-      {modal && (
-        <RepoModal
-          repo={modal === 'add' ? null : modal}
-          sshKeys={sshKeys}
-          onClose={() => setModal(null)}
-          onSaved={() => { setModal(null); loadRepos() }}
-        />
-      )}
-    </div>
-  )
-}
-
-function RepoModal({ repo, sshKeys, onClose, onSaved }) {
+function RepoForm({ repo, sshKeys, onClose, onSaved }) {
   const isEdit = !!repo
   const [form, setForm] = useState({
     name: repo?.name || '',
@@ -134,78 +43,175 @@ function RepoModal({ repo, sshKeys, onClose, onSaved }) {
   }
 
   return (
-    <div class="modal-overlay" onClick={e => e.target === e.currentTarget && onClose()}>
-      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
-        <div class="modal-header">
-          <h3 id="modal-title">{isEdit ? 'Edit repository' : 'Add repository'}</h3>
-          <button class="btn-close" onClick={onClose} aria-label="Close">
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06z"/></svg>
-          </button>
-        </div>
-        <div class="modal-body">
-          {error && <p class="settings-error">{error}</p>}
-          <div class="form-grid">
-            <label class="form-label">
-              Name
-              <input class="form-input" value={form.name} onInput={e => set('name', e.target.value)} placeholder="my-infra" />
-            </label>
-            <label class="form-label">
-              URL
-              <input class="form-input" value={form.url} onInput={e => set('url', e.target.value)} placeholder="git@github.com:user/repo.git" />
-            </label>
-            <label class="form-label">
-              Branch
-              <input class="form-input" value={form.branch} onInput={e => set('branch', e.target.value)} />
-            </label>
-            <label class="form-label">
-              Remote
-              <input class="form-input" value={form.remote} onInput={e => set('remote', e.target.value)} />
-            </label>
-            <label class="form-label">
-              Authentication
-              <select class="form-select" value={form.authType} onChange={e => set('authType', e.target.value)} name="authType">
-                <option value="none">None (public repo)</option>
-                <option value="ssh">SSH key</option>
-                <option value="pat">PAT (HTTPS)</option>
-              </select>
-            </label>
-            {form.authType === 'ssh' && (
-              <label class="form-label">
-                SSH key
-                <select class="form-select" value={form.sshKeyId} onChange={e => set('sshKeyId', e.target.value)} name="sshKeyId">
-                  <option value="">— select a key —</option>
-                  {sshKeys.map(k => <option key={k.id} value={k.id}>{k.name}</option>)}
-                </select>
-              </label>
-            )}
-            {form.authType === 'pat' && (
-              <label class="form-label">
-                Personal Access Token
-                <input class="form-input" type="password" value={form.pat} onInput={e => set('pat', e.target.value)}
-                  placeholder={isEdit ? '(leave blank to keep current)' : 'ghp_…'} />
-              </label>
-            )}
-            <label class="form-label">
-              Stacks directory
-              <input class="form-input" value={form.stacksDir} onInput={e => set('stacksDir', e.target.value)} placeholder="." />
-            </label>
-            <label class="form-label">
-              Sync interval (seconds)
-              <input class="form-input" type="number" value={form.syncInterval} onInput={e => set('syncInterval', e.target.value)} min="10" />
-            </label>
-            <label class="form-label form-checkbox-row">
-              <input type="checkbox" checked={form.enabled} onChange={e => set('enabled', e.target.checked)} />
-              Enabled
-            </label>
-          </div>
-        </div>
-        <div class="modal-footer">
-          <button class="btn-ghost" onClick={onClose}>Cancel</button>
-          <button class="btn-primary" onClick={save} disabled={saving}>
-            {saving ? 'Saving…' : 'Save'}
-          </button>
-        </div>
+    <div class="inline-form">
+      <div class="inline-form__title">{isEdit ? 'Edit repository' : 'Add repository'}</div>
+      {error && <p class="settings-error">{error}</p>}
+      <div class="form-grid">
+        <label class="form-label">
+          Name
+          <input class="form-input" value={form.name} onInput={e => set('name', e.target.value)} placeholder="my-infra" />
+        </label>
+        <label class="form-label">
+          URL
+          <input class="form-input" value={form.url} onInput={e => set('url', e.target.value)} placeholder="git@github.com:user/repo.git" />
+        </label>
+        <label class="form-label">
+          Branch
+          <input class="form-input" value={form.branch} onInput={e => set('branch', e.target.value)} />
+        </label>
+        <label class="form-label">
+          Remote
+          <input class="form-input" value={form.remote} onInput={e => set('remote', e.target.value)} />
+        </label>
+        <label class="form-label">
+          Authentication
+          <select class="form-select" value={form.authType} onChange={e => set('authType', e.target.value)} name="authType">
+            <option value="none">None (public repo)</option>
+            <option value="ssh">SSH key</option>
+            <option value="pat">PAT (HTTPS)</option>
+          </select>
+        </label>
+        {form.authType === 'ssh' && (
+          <label class="form-label">
+            SSH key
+            <select class="form-select" value={form.sshKeyId} onChange={e => set('sshKeyId', e.target.value)} name="sshKeyId">
+              <option value="">— select a key —</option>
+              {sshKeys.map(k => <option key={k.id} value={k.id}>{k.name}</option>)}
+            </select>
+          </label>
+        )}
+        {form.authType === 'pat' && (
+          <label class="form-label">
+            Personal Access Token
+            <input class="form-input" type="password" value={form.pat} onInput={e => set('pat', e.target.value)}
+              placeholder={isEdit ? '(leave blank to keep current)' : 'ghp_…'} />
+          </label>
+        )}
+        <label class="form-label">
+          Stacks directory
+          <input class="form-input" value={form.stacksDir} onInput={e => set('stacksDir', e.target.value)} placeholder="." />
+        </label>
+        <label class="form-label">
+          Sync interval (seconds)
+          <input class="form-input" type="number" value={form.syncInterval} onInput={e => set('syncInterval', e.target.value)} min="10" />
+        </label>
+        <label class="form-label form-checkbox-row">
+          <input type="checkbox" checked={form.enabled} onChange={e => set('enabled', e.target.checked)} />
+          Enabled
+        </label>
       </div>
+      <div class="form-actions">
+        <button class="btn-ghost" onClick={onClose}>Cancel</button>
+        <button class="btn-primary" onClick={save} disabled={saving}>
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function ReposTab({ sshKeys }) {
+  const [repos, setRepos] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [showForm, setShowForm] = useState(false) // false | 'add' | repo object
+  const [deleteConfirm, setDeleteConfirm] = useState(null) // null | repo id
+
+  const loadRepos = () => {
+    setLoading(true)
+    fetch('/api/settings/repos')
+      .then(r => r.json())
+      .then(data => { setRepos(data); setLoading(false) })
+      .catch(e => { setError(e.message); setLoading(false) })
+  }
+
+  useEffect(loadRepos, [])
+
+  const deleteRepo = async (id) => {
+    await fetch(`/api/settings/repos/${id}`, { method: 'DELETE' })
+    setDeleteConfirm(null)
+    loadRepos()
+  }
+
+  return (
+    <div class="settings-tab">
+      <div class="settings-tab__header">
+        <h2>Repositories</h2>
+        {!showForm && (
+          <button class="btn-primary" onClick={() => setShowForm('add')}>+ Add repo</button>
+        )}
+      </div>
+
+      {showForm && (
+        <RepoForm
+          repo={showForm === 'add' ? null : showForm}
+          sshKeys={sshKeys}
+          onClose={() => setShowForm(false)}
+          onSaved={() => { setShowForm(false); loadRepos() }}
+        />
+      )}
+
+      {error && <p class="settings-error">{error}</p>}
+      {loading ? (
+        <p class="settings-loading">Loading…</p>
+      ) : repos.length === 0 ? (
+        <div class="settings-empty">
+          <p>No repos configured.</p>
+          <p>Add a repository to start syncing Docker Compose stacks.</p>
+        </div>
+      ) : (
+        <div class="table-wrap">
+          <table class="settings-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>URL</th>
+                <th>Branch</th>
+                <th>Auth</th>
+                <th>Stacks dir</th>
+                <th>Interval</th>
+                <th>Status</th>
+                <th aria-label="Actions"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {repos.map(repo => (
+                <tr key={repo.id}>
+                  <td class="td-name">{repo.name}</td>
+                  <td class="td-url">{repo.url}</td>
+                  <td>{repo.branch}</td>
+                  <td>{repo.authType || 'none'}</td>
+                  <td class="td-mono">{repo.stacksDir || '.'}</td>
+                  <td>{repo.syncInterval}s</td>
+                  <td>
+                    <span class={`status-pill ${repo.enabled ? 'status-pill--on' : 'status-pill--off'}`}>
+                      {repo.enabled ? 'enabled' : 'disabled'}
+                    </span>
+                  </td>
+                  <td class="td-actions">
+                    {deleteConfirm === repo.id ? (
+                      <span class="confirm-row">
+                        Delete {repo.name}?
+                        <button class="btn-ghost btn-sm btn-danger-confirm" onClick={() => deleteRepo(repo.id)}>Confirm</button>
+                        <button class="btn-ghost btn-sm" onClick={() => setDeleteConfirm(null)}>Cancel</button>
+                      </span>
+                    ) : (
+                      <>
+                        <button class="btn-icon" onClick={() => { setShowForm(repo); setDeleteConfirm(null) }} aria-label="Edit repo">
+                          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M11.013 1.427a1.75 1.75 0 0 1 2.474 0l1.086 1.086a1.75 1.75 0 0 1 0 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 0 1-.927-.928l.929-3.25c.081-.286.235-.547.445-.758l8.61-8.61z"/></svg>
+                        </button>
+                        <button class="btn-icon btn-icon--danger" onClick={() => setDeleteConfirm(repo.id)} aria-label="Delete repo">
+                          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M11 1.75V3h2.25a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1 0-1.5H5V1.75C5 .784 5.784 0 6.75 0h2.5C10.216 0 11 .784 11 1.75zM6.5 1.75V3h3V1.75a.25.25 0 0 0-.25-.25h-2.5a.25.25 0 0 0-.25.25zM4.997 6.5a.75.75 0 1 0-1.5.006l.139 9.25a.75.75 0 0 0 1.5-.005zm5.006.006a.75.75 0 0 0-1.5-.006l-.139 9.25a.75.75 0 0 0 1.5.005z"/></svg>
+                        </button>
+                      </>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   )
 }
@@ -219,6 +225,7 @@ function SSHKeysTab({ onKeysChange }) {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState(null)
   const [success, setSuccess] = useState(null)
+  const [deleteConfirm, setDeleteConfirm] = useState(null) // null | key id
 
   const loadKeys = () => {
     setLoading(true)
@@ -249,9 +256,9 @@ function SSHKeysTab({ onKeysChange }) {
     } catch (e) { setError(e.message); setSaving(false) }
   }
 
-  const deleteKey = async (id, name) => {
-    if (!confirm(`Delete "${name}"? Repos using it will fail to sync.`)) return
+  const deleteKey = async (id) => {
     await fetch(`/api/settings/ssh-keys/${id}`, { method: 'DELETE' })
+    setDeleteConfirm(null)
     loadKeys()
   }
 
@@ -300,9 +307,17 @@ function SSHKeysTab({ onKeysChange }) {
                   <span class="key-item__name">{k.name}</span>
                   <span class="key-item__pub mono">{k.publicKey}</span>
                 </div>
-                <button class="btn-icon btn-icon--danger" onClick={() => deleteKey(k.id, k.name)} aria-label={`Delete ${k.name}`}>
-                  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M11 1.75V3h2.25a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1 0-1.5H5V1.75C5 .784 5.784 0 6.75 0h2.5C10.216 0 11 .784 11 1.75zM6.5 1.75V3h3V1.75a.25.25 0 0 0-.25-.25h-2.5a.25.25 0 0 0-.25.25zM4.997 6.5a.75.75 0 1 0-1.5.006l.139 9.25a.75.75 0 0 0 1.5-.005zm5.006.006a.75.75 0 0 0-1.5-.006l-.139 9.25a.75.75 0 0 0 1.5.005z"/></svg>
-                </button>
+                {deleteConfirm === k.id ? (
+                  <span class="confirm-row">
+                    Delete {k.name}?
+                    <button class="btn-ghost btn-sm btn-danger-confirm" onClick={() => deleteKey(k.id)}>Confirm</button>
+                    <button class="btn-ghost btn-sm" onClick={() => setDeleteConfirm(null)}>Cancel</button>
+                  </span>
+                ) : (
+                  <button class="btn-icon btn-icon--danger" onClick={() => setDeleteConfirm(k.id)} aria-label={`Delete ${k.name}`}>
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M11 1.75V3h2.25a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1 0-1.5H5V1.75C5 .784 5.784 0 6.75 0h2.5C10.216 0 11 .784 11 1.75zM6.5 1.75V3h3V1.75a.25.25 0 0 0-.25-.25h-2.5a.25.25 0 0 0-.25.25zM4.997 6.5a.75.75 0 1 0-1.5.006l.139 9.25a.75.75 0 0 0 1.5-.005zm5.006.006a.75.75 0 0 0-1.5-.006l-.139 9.25a.75.75 0 0 0 1.5.005z"/></svg>
+                  </button>
+                )}
               </div>
             ))}
           </div>

--- a/main.go
+++ b/main.go
@@ -37,6 +37,13 @@ const maxSyncFailures = 10
 var repoBackoffs sync.Map // key: repo name (string), value: *syncBackoff
 var repoLocks sync.Map   // key: repo name (string), value: *sync.Mutex
 
+// InfisicalConfig holds Infisical credentials loaded from DB settings.
+type InfisicalConfig struct {
+	Token string
+	Env   string
+	URL   string
+}
+
 func getBackoff(repoName string) *syncBackoff {
 v, _ := repoBackoffs.LoadOrStore(repoName, &syncBackoff{})
 return v.(*syncBackoff)
@@ -125,42 +132,33 @@ func redactSecretEnv(key, value string) string {
 // "docker compose up -d" or an "infisical run -- docker compose up -d" command depending
 // on the INFISICAL_ENABLED env var and available credentials. The provided ctx is used
 // directly, so callers should set an appropriate deadline before calling.
-func buildComposeCmd(ctx context.Context, stackPath, stackName string) *exec.Cmd {
-if strings.ToLower(os.Getenv("INFISICAL_ENABLED")) != "true" {
-slog.Info("applying stack", "stack", stackName, "infisical", false)
-return exec.CommandContext(ctx, "docker", "compose", "up", "-d")
-}
+func buildComposeCmd(ctx context.Context, stackPath, stackName string, cfg InfisicalConfig) *exec.Cmd {
+	tomlPath := filepath.Join(stackPath, "infisical.toml")
+	_, tomlErr := os.Stat(tomlPath)
+	hasToml := tomlErr == nil
 
-args := []string{"run"}
-configured := false
+	if !hasToml && cfg.Token == "" {
+		slog.Info("applying stack", "stack", stackName, "infisical", false)
+		return exec.CommandContext(ctx, "docker", "compose", "up", "-d")
+	}
 
-tomlPath := filepath.Join(stackPath, "infisical.toml")
-if _, err := os.Stat(tomlPath); err == nil {
-args = append(args, "--config="+tomlPath)
-slog.Info("stack using per-stack infisical.toml", "stack", stackName)
-configured = true
-} else if token := os.Getenv("INFISICAL_TOKEN"); token != "" {
-args = append(args, "--token="+token)
-infisicalEnv := os.Getenv("INFISICAL_ENV")
-if infisicalEnv == "" {
-infisicalEnv = "prod"
-}
-args = append(args, "--env="+infisicalEnv)
-slog.Info("stack using global infisical token", "stack", stackName, "env", infisicalEnv)
-configured = true
-} else {
-slog.Warn("INFISICAL_ENABLED=true but no credentials found, applying without secrets injection", "stack", stackName)
-}
+	if hasToml {
+		args := []string{"run", "--config=" + tomlPath}
+		if cfg.URL != "" {
+			args = append(args, "--domain="+cfg.URL)
+		}
+		args = append(args, "--", "docker", "compose", "up", "-d")
+		slog.Info("stack using per-stack infisical.toml", "stack", stackName)
+		return exec.CommandContext(ctx, "infisical", args...)
+	}
 
-if configured {
-if infisicalURL := os.Getenv("INFISICAL_URL"); infisicalURL != "" {
-args = append(args, "--domain="+infisicalURL)
-}
-args = append(args, "--", "docker", "compose", "up", "-d")
-return exec.CommandContext(ctx, "infisical", args...)
-}
-
-return exec.CommandContext(ctx, "docker", "compose", "up", "-d")
+	args := []string{"run", "--token=" + cfg.Token, "--env=" + cfg.Env}
+	if cfg.URL != "" {
+		args = append(args, "--domain="+cfg.URL)
+	}
+	args = append(args, "--", "docker", "compose", "up", "-d")
+	slog.Info("stack using global infisical token", "stack", stackName, "env", cfg.Env)
+	return exec.CommandContext(ctx, "infisical", args...)
 }
 
 // refreshContainers updates container details for all stacks whose StackDir is
@@ -230,7 +228,7 @@ func latestStartedAt(containers []state.ContainerDetail) time.Time {
 }
 
 
-func applyStack(ctx context.Context, stackPath, stackName, repoName string, store *state.Store, dockerClient *docker.Client) {
+func applyStack(ctx context.Context, stackPath, stackName, repoName string, store *state.Store, dockerClient *docker.Client, infisicalCfg InfisicalConfig) {
 if store != nil {
 store.UpdateStack(state.StackState{
 Name:       stackName,
@@ -243,7 +241,7 @@ Containers: []state.ContainerDetail{},
 
 applyCtx, applyCancel := context.WithTimeout(ctx, 300*time.Second)
 defer applyCancel()
-cmd := buildComposeCmd(applyCtx, stackPath, stackName)
+cmd := buildComposeCmd(applyCtx, stackPath, stackName, infisicalCfg)
 cmd.Dir = stackPath
 output, err := cmd.CombinedOutput()
 outputStr := string(output)
@@ -309,7 +307,7 @@ slog.Info("stack applied successfully", "stack", stackName)
 
 
 // runStacksSync discovers and applies all docker-compose stacks in stacksDir.
-func runStacksSync(ctx context.Context, stacksDir, repoName string, store *state.Store, dockerClient *docker.Client) {
+func runStacksSync(ctx context.Context, stacksDir, repoName string, store *state.Store, dockerClient *docker.Client, infisicalCfg InfisicalConfig) {
 	if stacksDir == "" {
 		return
 	}
@@ -336,14 +334,19 @@ func runStacksSync(ctx context.Context, stacksDir, repoName string, store *state
 			slog.Warn("no compose file found, skipping stack", "stack", stackName, "repo", repoName)
 			continue
 		}
-		applyStack(ctx, stackPath, stackName, repoName, store, dockerClient)
+		applyStack(ctx, stackPath, stackName, repoName, store, dockerClient, infisicalCfg)
 	}
 }
 
 // syncRepoFromDB clones or pulls the repo and applies stacks if the SHA changed.
-func syncRepoFromDB(ctx context.Context, repo db.RepoDB, cloneDir string, cryptoKey []byte, sqlDB *sql.DB, syncInterval time.Duration, store *state.Store, dockerClient *docker.Client) {
+func syncRepoFromDB(ctx context.Context, repo db.RepoDB, cloneDir string, cryptoKey []byte, sqlDB *sql.DB, store *state.Store, dockerClient *docker.Client, infisicalCfg InfisicalConfig) {
 	repoName := repo.Name
 	start := time.Now()
+
+	syncInterval := time.Duration(repo.SyncInterval) * time.Second
+	if syncInterval <= 0 {
+		syncInterval = 60 * time.Second
+	}
 
 	if store != nil {
 		existing, ok := store.GetRepo(repoName)
@@ -426,7 +429,7 @@ func syncRepoFromDB(ctx context.Context, repo db.RepoDB, cloneDir string, crypto
 
 	if newSHA != oldSHA || oldSHA == "" {
 		stacksDir := filepath.Join(destDir, repo.StacksDir)
-		runStacksSync(ctx, stacksDir, repoName, store, dockerClient)
+		runStacksSync(ctx, stacksDir, repoName, store, dockerClient, infisicalCfg)
 	}
 
 	if store != nil {
@@ -439,6 +442,27 @@ func syncRepoFromDB(ctx context.Context, repo db.RepoDB, cloneDir string, crypto
 	}
 	recordSyncSuccess(repoName)
 	metrics.RecordSync(repoName, "success", time.Since(start))
+}
+
+func loadInfisicalFromDB(ctx context.Context, sqlDB *sql.DB, cryptoKey []byte) InfisicalConfig {
+	cfg := InfisicalConfig{Env: "prod"}
+	settings, err := db.GetAllSettings(ctx, sqlDB)
+	if err != nil {
+		slog.Warn("failed to load settings from DB", "err", err)
+		return cfg
+	}
+	if v := settings["infisical_env"]; v != "" {
+		cfg.Env = v
+	}
+	cfg.URL = settings["infisical_url"]
+	// GetAllSettings masks sensitive values; fetch token separately
+	tokenEnc, _, err := db.GetSetting(ctx, sqlDB, "infisical_token")
+	if err == nil && tokenEnc != "" {
+		if token, err := cryptoModule.Decrypt(cryptoKey, tokenEnc); err == nil {
+			cfg.Token = token
+		}
+	}
+	return cfg
 }
 
 func main() {
@@ -485,11 +509,7 @@ func main() {
 		cloneDir = "/var/lib/stackd/repos"
 	}
 
-	syncIntervalSeconds := 60
-	if v, err := strconv.Atoi(os.Getenv("SYNC_INTERVAL_SECONDS")); err == nil && v > 0 {
-		syncIntervalSeconds = v
-	}
-	syncInterval := time.Duration(syncIntervalSeconds) * time.Second
+	syncInterval := 60 * time.Second
 
 	// --- Open DB ---
 	sqlDB, err := db.Open(dbURL)
@@ -517,10 +537,12 @@ func main() {
 	if strings.ToLower(os.Getenv("DEV_SEED")) == "true" {
 		seedDevState(store)
 	}
-	store.SetInfisical(state.InfisicalState{
-		Enabled: strings.ToLower(os.Getenv("INFISICAL_ENABLED")) == "true",
-		Env:     os.Getenv("INFISICAL_ENV"),
-	})
+	{
+		initSettingsCtx, initSettingsCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		infCfg := loadInfisicalFromDB(initSettingsCtx, sqlDB, cryptoKey)
+		initSettingsCancel()
+		store.SetInfisical(state.InfisicalState{Enabled: infCfg.Token != "", Env: infCfg.Env})
+	}
 
 	// --- Docker client ---
 	var dockerClient *docker.Client
@@ -540,11 +562,14 @@ func main() {
 	if err != nil {
 		slog.Error("failed to list repos from DB", "err", err)
 	} else {
+		startupSettingsCtx, startupSettingsCancel := context.WithTimeout(ctx, 5*time.Second)
+		startupInfCfg := loadInfisicalFromDB(startupSettingsCtx, sqlDB, cryptoKey)
+		startupSettingsCancel()
 		for _, repo := range startupRepos {
 			if !repo.Enabled {
 				continue
 			}
-			syncRepoFromDB(ctx, repo, cloneDir, cryptoKey, sqlDB, syncInterval, store, dockerClient)
+			syncRepoFromDB(ctx, repo, cloneDir, cryptoKey, sqlDB, store, dockerClient, startupInfCfg)
 		}
 		refreshContainers(ctx, store, &dockerClient)
 	}
@@ -557,7 +582,7 @@ func main() {
 	ticker := time.NewTicker(syncInterval)
 	defer ticker.Stop()
 
-	doSyncRound := func(repos []db.RepoDB) {
+	doSyncRound := func(repos []db.RepoDB, infisicalCfg InfisicalConfig) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -572,7 +597,7 @@ func main() {
 					slog.Info("skipping sync (backoff)", "repo", repo.Name)
 					continue
 				}
-				syncRepoFromDB(ctx, repo, cloneDir, cryptoKey, sqlDB, syncInterval, store, dockerClient)
+				syncRepoFromDB(ctx, repo, cloneDir, cryptoKey, sqlDB, store, dockerClient, infisicalCfg)
 			}
 			refreshContainers(ctx, store, &dockerClient)
 		}()
@@ -588,7 +613,12 @@ func main() {
 			repos = nil
 		}
 
-		doSyncRound(repos)
+		settingsCtx, settingsCancel := context.WithTimeout(ctx, 5*time.Second)
+		infCfg := loadInfisicalFromDB(settingsCtx, sqlDB, cryptoKey)
+		settingsCancel()
+		store.SetInfisical(state.InfisicalState{Enabled: infCfg.Token != "", Env: infCfg.Env})
+
+		doSyncRound(repos, infCfg)
 
 		select {
 		case <-ctx.Done():
@@ -618,9 +648,12 @@ func main() {
 			}
 			slog.Info("manual sync triggered", "repo", repoName)
 			resetBackoff(repoName)
+			trigSettingsCtx, trigSettingsCancel := context.WithTimeout(ctx, 5*time.Second)
+			trigInfCfg := loadInfisicalFromDB(trigSettingsCtx, sqlDB, cryptoKey)
+			trigSettingsCancel()
 			for _, repo := range repos {
 				if repo.Name == repoName {
-					syncRepoFromDB(ctx, repo, cloneDir, cryptoKey, sqlDB, syncInterval, store, dockerClient)
+					syncRepoFromDB(ctx, repo, cloneDir, cryptoKey, sqlDB, store, dockerClient, trigInfCfg)
 					break
 				}
 			}


### PR DESCRIPTION
Phase 4 of v2 architectural upgrade. Adds full settings UI with repos, SSH keys, and general config management.

## Changes
- **ReposTab**: inline add/edit form (no modal), inline delete confirmation (no browser dialogs)
- **SSHKeysTab**: inline delete confirmation
- **GeneralTab**: Infisical, git user, pull_only settings
- Header nav already present from Phase 3
- Matches existing design system
- Fix pre-existing build error: `ctx` used before declaration in `main()` init block