### PR TITLE
fix: Postgres compatibility

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -20,13 +20,35 @@ import (
 //go:embed migrations/*.sql
 var migrationsFS embed.FS
 
+// driverName holds the current DB driver ("sqlite" or "postgres").
+// Set by Open; used by Rebind.
+var driverName string
+
+// Rebind rewrites ? placeholders to $1, $2, … for Postgres.
+// For SQLite it returns the query unchanged.
+func Rebind(query string) string {
+	if driverName != "postgres" {
+		return query
+	}
+	var b strings.Builder
+	n := 1
+	for i := 0; i < len(query); i++ {
+		if query[i] == '?' {
+			fmt.Fprintf(&b, "$%d", n)
+			n++
+		} else {
+			b.WriteByte(query[i])
+		}
+	}
+	return b.String()
+}
+
 // Open opens the database, runs migrations, and returns the *sql.DB.
 // dbURL may be "sqlite://./stackd.db" or "postgres://...".
 func Open(dbURL string) (*sql.DB, error) {
 	var (
-		db     *sql.DB
-		err    error
-		driver string
+		db  *sql.DB
+		err error
 	)
 
 	scheme, _, found := strings.Cut(dbURL, "://")
@@ -45,13 +67,13 @@ func Open(dbURL string) (*sql.DB, error) {
 			db.Close()
 			return nil, fmt.Errorf("db.Open WAL pragma: %w", err)
 		}
-		driver = "sqlite"
+		driverName = "sqlite"
 	case "postgres", "postgresql":
 		db, err = sql.Open("pgx", dbURL)
 		if err != nil {
 			return nil, fmt.Errorf("db.Open postgres: %w", err)
 		}
-		driver = "postgres"
+		driverName = "postgres"
 	default:
 		return nil, fmt.Errorf("db.Open: unsupported scheme %q", scheme)
 	}
@@ -70,15 +92,30 @@ func Open(dbURL string) (*sql.DB, error) {
 	m, err := migrate.NewWithSourceInstance("iofs", src, dbURL)
 	if err != nil {
 		db.Close()
-		return nil, fmt.Errorf("db.Open migrate: %w", err)
+		return nil, fmt.Errorf("db.Open migrate: failed to open database: %w", err)
 	}
 	defer m.Close()
 
 	if err = m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
-		db.Close()
-		return nil, fmt.Errorf("db.Open migrate up: %w", err)
+		// Dirty state means a previous migration attempt failed mid-run.
+		// Force version back to uninitialized so we can retry cleanly.
+		var dirtyErr *migrate.ErrDirty
+		if errors.As(err, &dirtyErr) {
+			slog.Warn("dirty migration state detected, forcing reset", "version", dirtyErr.Version)
+			if ferr := m.Force(-1); ferr != nil {
+				db.Close()
+				return nil, fmt.Errorf("db.Open migrate force: %w", ferr)
+			}
+			if err = m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+				db.Close()
+				return nil, fmt.Errorf("db.Open migrate up (retry): %w", err)
+			}
+		} else {
+			db.Close()
+			return nil, fmt.Errorf("db.Open migrate up: %w", err)
+		}
 	}
 
-	slog.Info("database ready", "driver", driver, "url", dbURL)
+	slog.Info("database ready", "driver", driverName, "url", dbURL)
 	return db, nil
 }

--- a/internal/db/migrations/001_initial.up.sql
+++ b/internal/db/migrations/001_initial.up.sql
@@ -1,17 +1,17 @@
 CREATE TABLE IF NOT EXISTS repos (
-    id          TEXT PRIMARY KEY,
-    name        TEXT NOT NULL UNIQUE,
-    url         TEXT NOT NULL,
-    branch      TEXT NOT NULL DEFAULT 'main',
-    remote      TEXT NOT NULL DEFAULT 'origin',
-    auth_type   TEXT NOT NULL DEFAULT 'none',
-    ssh_key_id  TEXT,
-    pat_enc     TEXT,
-    stacks_dir  TEXT NOT NULL DEFAULT '.',
+    id            TEXT PRIMARY KEY,
+    name          TEXT NOT NULL UNIQUE,
+    url           TEXT NOT NULL,
+    branch        TEXT NOT NULL DEFAULT 'main',
+    remote        TEXT NOT NULL DEFAULT 'origin',
+    auth_type     TEXT NOT NULL DEFAULT 'none',
+    ssh_key_id    TEXT,
+    pat_enc       TEXT,
+    stacks_dir    TEXT NOT NULL DEFAULT '.',
     sync_interval INTEGER NOT NULL DEFAULT 60,
-    enabled     INTEGER NOT NULL DEFAULT 1,
-    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
-    updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    enabled       INTEGER NOT NULL DEFAULT 1,
+    created_at    TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS ssh_keys (
@@ -19,20 +19,21 @@ CREATE TABLE IF NOT EXISTS ssh_keys (
     name            TEXT NOT NULL UNIQUE,
     private_key_enc TEXT NOT NULL,
     public_key      TEXT NOT NULL,
-    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+    created_at      TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS settings (
-    key         TEXT PRIMARY KEY,
-    value       TEXT,
-    sensitive   INTEGER NOT NULL DEFAULT 0,
-    updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    key        TEXT PRIMARY KEY,
+    value      TEXT,
+    sensitive  INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-INSERT OR IGNORE INTO settings (key, value, sensitive) VALUES
-    ('infisical_token',    '', 1),
-    ('infisical_env',      'prod', 0),
-    ('infisical_url',      '', 0),
-    ('git_user_name',      'stackd', 0),
-    ('git_user_email',     'stackd@localhost', 0),
-    ('pull_only',          'false', 0);
+INSERT INTO settings (key, value, sensitive) VALUES
+    ('infisical_token',  '', 1),
+    ('infisical_env',    'prod', 0),
+    ('infisical_url',    '', 0),
+    ('git_user_name',    'stackd', 0),
+    ('git_user_email',   'stackd@localhost', 0),
+    ('pull_only',        'false', 0)
+ON CONFLICT (key) DO NOTHING;

--- a/internal/db/repo_store.go
+++ b/internal/db/repo_store.go
@@ -77,9 +77,9 @@ func ListRepos(ctx context.Context, db *sql.DB) ([]RepoDB, error) {
 
 func GetRepo(ctx context.Context, db *sql.DB, id string) (RepoDB, error) {
 	row := db.QueryRowContext(ctx,
-		`SELECT id, name, url, branch, remote, auth_type, ssh_key_id, pat_enc,
+		Rebind(`SELECT id, name, url, branch, remote, auth_type, ssh_key_id, pat_enc,
                 stacks_dir, sync_interval, enabled, created_at, updated_at
-         FROM repos WHERE id = ?`, id)
+         FROM repos WHERE id = ?`), id)
 	r, err := scanRepo(row)
 	if err != nil {
 		return RepoDB{}, fmt.Errorf("getRepo: %w", err)
@@ -93,9 +93,9 @@ func CreateRepo(ctx context.Context, db *sql.DB, r RepoDB) error {
 	}
 	now := time.Now().UTC().Format(time.DateTime)
 	_, err := db.ExecContext(ctx,
-		`INSERT INTO repos (id, name, url, branch, remote, auth_type, ssh_key_id, pat_enc,
+		Rebind(`INSERT INTO repos (id, name, url, branch, remote, auth_type, ssh_key_id, pat_enc,
                             stacks_dir, sync_interval, enabled, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
 		r.ID, r.Name, r.URL, r.Branch, r.Remote,
 		r.AuthType, nullStr(r.SSHKeyID), nullStr(r.PATEnc),
 		r.StacksDir, r.SyncInterval, boolInt(r.Enabled), now, now,
@@ -109,10 +109,10 @@ func CreateRepo(ctx context.Context, db *sql.DB, r RepoDB) error {
 func UpdateRepo(ctx context.Context, db *sql.DB, r RepoDB) error {
 	now := time.Now().UTC().Format(time.DateTime)
 	_, err := db.ExecContext(ctx,
-		`UPDATE repos SET name=?, url=?, branch=?, remote=?, auth_type=?,
+		Rebind(`UPDATE repos SET name=?, url=?, branch=?, remote=?, auth_type=?,
                           ssh_key_id=?, pat_enc=?, stacks_dir=?, sync_interval=?,
                           enabled=?, updated_at=?
-         WHERE id=?`,
+         WHERE id=?`),
 		r.Name, r.URL, r.Branch, r.Remote, r.AuthType,
 		nullStr(r.SSHKeyID), nullStr(r.PATEnc),
 		r.StacksDir, r.SyncInterval, boolInt(r.Enabled), now, r.ID,
@@ -124,7 +124,7 @@ func UpdateRepo(ctx context.Context, db *sql.DB, r RepoDB) error {
 }
 
 func DeleteRepo(ctx context.Context, db *sql.DB, id string) error {
-	_, err := db.ExecContext(ctx, `DELETE FROM repos WHERE id=?`, id)
+	_, err := db.ExecContext(ctx, Rebind(`DELETE FROM repos WHERE id=?`), id)
 	if err != nil {
 		return fmt.Errorf("deleteRepo: %w", err)
 	}

--- a/internal/db/settings_store.go
+++ b/internal/db/settings_store.go
@@ -11,7 +11,7 @@ func GetSetting(ctx context.Context, db *sql.DB, key string) (value string, sens
 	var sensitiveInt int
 	var nullValue sql.NullString
 	err = db.QueryRowContext(ctx,
-		`SELECT value, sensitive FROM settings WHERE key=?`, key,
+		Rebind(`SELECT value, sensitive FROM settings WHERE key=?`), key,
 	).Scan(&nullValue, &sensitiveInt)
 	if err != nil {
 		return "", false, fmt.Errorf("getSetting %q: %w", key, err)
@@ -22,7 +22,7 @@ func GetSetting(ctx context.Context, db *sql.DB, key string) (value string, sens
 func SetSetting(ctx context.Context, db *sql.DB, key, value string) error {
 	now := time.Now().UTC().Format(time.DateTime)
 	_, err := db.ExecContext(ctx,
-		`UPDATE settings SET value=?, updated_at=? WHERE key=?`, value, now, key,
+		Rebind(`UPDATE settings SET value=?, updated_at=? WHERE key=?`), value, now, key,
 	)
 	if err != nil {
 		return fmt.Errorf("setSetting %q: %w", key, err)

--- a/internal/db/ssh_key_store.go
+++ b/internal/db/ssh_key_store.go
@@ -39,7 +39,7 @@ func GetSSHKey(ctx context.Context, db *sql.DB, id string) (SSHKeyDB, error) {
 	var k SSHKeyDB
 	var createdAt string
 	err := db.QueryRowContext(ctx,
-		`SELECT id, name, private_key_enc, public_key, created_at FROM ssh_keys WHERE id=?`, id,
+		Rebind(`SELECT id, name, private_key_enc, public_key, created_at FROM ssh_keys WHERE id=?`), id,
 	).Scan(&k.ID, &k.Name, &k.PrivateKeyEnc, &k.PublicKey, &createdAt)
 	if err != nil {
 		return SSHKeyDB{}, fmt.Errorf("getSSHKey: %w", err)
@@ -54,7 +54,7 @@ func CreateSSHKey(ctx context.Context, db *sql.DB, k SSHKeyDB) error {
 	}
 	now := time.Now().UTC().Format(time.DateTime)
 	_, err := db.ExecContext(ctx,
-		`INSERT INTO ssh_keys (id, name, private_key_enc, public_key, created_at) VALUES (?, ?, ?, ?, ?)`,
+		Rebind(`INSERT INTO ssh_keys (id, name, private_key_enc, public_key, created_at) VALUES (?, ?, ?, ?, ?)`),
 		k.ID, k.Name, k.PrivateKeyEnc, k.PublicKey, now,
 	)
 	if err != nil {
@@ -64,7 +64,7 @@ func CreateSSHKey(ctx context.Context, db *sql.DB, k SSHKeyDB) error {
 }
 
 func DeleteSSHKey(ctx context.Context, db *sql.DB, id string) error {
-	_, err := db.ExecContext(ctx, `DELETE FROM ssh_keys WHERE id=?`, id)
+	_, err := db.ExecContext(ctx, Rebind(`DELETE FROM ssh_keys WHERE id=?`), id)
 	if err != nil {
 		return fmt.Errorf("deleteSSHKey: %w", err)
 	}


### PR DESCRIPTION
Fixes stackd failing to start with Postgres.

**Root causes:**
1. Migration SQL used SQLite-specific syntax (`INSERT OR IGNORE`, `datetime('now')`)
2. All store queries used `?` placeholders — Postgres requires `$1, $2, ...`
3. Failed migration left DB in dirty state causing infinite crash loop

**Fixes:**
- `CURRENT_TIMESTAMP` replaces `datetime('now')` (valid in both)
- `INSERT INTO ... ON CONFLICT DO NOTHING` replaces `INSERT OR IGNORE INTO` (valid in both)
- `Rebind()` helper in db package rewrites `?` → `$1, $2, ...` for Postgres, no-op for SQLite
- Dirty migration auto-recovery: detects `ErrDirty`, forces version -1, retries

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>