### PR TITLE
feat: status-colored left borders on stack cards

### DIFF
--- a/internal/ui/src/components/AppGrid.css
+++ b/internal/ui/src/components/AppGrid.css
@@ -216,7 +216,6 @@
 
 .stack-card:hover {
   background: var(--bg-hover);
-  border-left-color: var(--border-color);
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
 }
@@ -290,6 +289,14 @@
   font-size: var(--text-xs);
   margin-top: 1px;
 }
+
+/* ── Stack card status colors ────────────────────── */
+.stack-card--running  { border-left-color: var(--status-running); }
+.stack-card--stopped  { border-left-color: var(--status-stopped);  background: color-mix(in srgb, var(--status-stopped)  5%, var(--bg-primary)); }
+.stack-card--error    { border-left-color: var(--status-error);    background: color-mix(in srgb, var(--status-error)    5%, var(--bg-primary)); }
+.stack-card--degraded { border-left-color: var(--status-degraded); background: color-mix(in srgb, var(--status-degraded) 4%, var(--bg-primary)); }
+.stack-card--applying { border-left-color: var(--status-applying); }
+.stack-card--unknown  { border-left-color: var(--status-unknown); }
 
 /* ── Stack badges ────────────────────────────────── */
 .stack-badge {


### PR DESCRIPTION
## Summary
- Each stack card now shows a colored left border matching its health state (green = running, red = stopped/error, amber = degraded, blue = applying, gray = unknown)
- Stopped/error/degraded cards get a subtle background tint (4–5%) to make problem stacks stand out at a glance
- Removed the generic hover rule that was overwriting the status border color with gray

## Test plan
- [ ] Verify running stacks show green left border
- [ ] Verify stopped/error stacks show red border + faint red tint
- [ ] Verify degraded stacks show amber border + faint amber tint
- [ ] Verify applying stacks show blue border
- [ ] Verify selected card overrides status color with indigo accent
- [ ] Verify hover still shows lift/shadow without losing status border color

🤖 Generated with [Claude Code](https://claude.com/claude-code)