### PR TITLE
docs: harmonize agent instructions (CLAUDE.md / AGENTS.md / copilot)

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,0 +1,73 @@
+# Dolt database (managed by Dolt, not git)
+dolt/
+embeddeddolt/
+
+# Runtime files
+bd.sock
+bd.sock.startlock
+sync-state.json
+last-touched
+.exclusive-lock
+
+# Daemon runtime (lock, log, pid)
+daemon.*
+
+# Interactions log (runtime, not versioned)
+interactions.jsonl
+
+# Push state (runtime, per-machine)
+push-state.json
+
+# Lock files (various runtime locks)
+*.lock
+
+# Credential key (encryption key for federation peer auth — never commit)
+.beads-credential-key
+
+# Local version tracking (prevents upgrade notification spam after git ops)
+.local_version
+
+# Worktree redirect file (contains relative path to main repo's .beads/)
+# Must not be committed as paths would be wrong in other clones
+redirect
+
+# Sync state (local-only, per-machine)
+# These files are machine-specific and should not be shared across clones
+.sync.lock
+export-state/
+export-state.json
+
+# Ephemeral store (SQLite - wisps/molecules, intentionally not versioned)
+ephemeral.sqlite3
+ephemeral.sqlite3-journal
+ephemeral.sqlite3-wal
+ephemeral.sqlite3-shm
+
+# Dolt server management (auto-started by bd)
+dolt-server.pid
+dolt-server.log
+dolt-server.lock
+dolt-server.port
+dolt-server.activity
+
+# Corrupt backup directories (created by bd doctor --fix recovery)
+*.corrupt.backup/
+
+# Backup data (auto-exported JSONL, local-only)
+backup/
+
+# Per-project environment file (Dolt connection config, GH#2520)
+.env
+
+# Legacy files (from pre-Dolt versions)
+*.db
+*.db?*
+*.db-journal
+*.db-wal
+*.db-shm
+db.sqlite
+bd.db
+# NOTE: Do NOT add negation patterns here.
+# They would override fork protection in .git/info/exclude.
+# Config files (metadata.json, config.yaml) are tracked by git by default
+# since no pattern above ignores them.

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -1,0 +1,81 @@
+# Beads - AI-Native Issue Tracking
+
+Welcome to Beads! This repository uses **Beads** for issue tracking - a modern, AI-native tool designed to live directly in your codebase alongside your code.
+
+## What is Beads?
+
+Beads is issue tracking that lives in your repo, making it perfect for AI coding agents and developers who want their issues close to their code. No web UI required - everything works through the CLI and integrates seamlessly with git.
+
+**Learn more:** [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
+
+## Quick Start
+
+### Essential Commands
+
+```bash
+# Create new issues
+bd create "Add user authentication"
+
+# View all issues
+bd list
+
+# View issue details
+bd show <issue-id>
+
+# Update issue status
+bd update <issue-id> --claim
+bd update <issue-id> --status done
+
+# Sync with Dolt remote
+bd dolt push
+```
+
+### Working with Issues
+
+Issues in Beads are:
+- **Git-native**: Stored in Dolt database with version control and branching
+- **AI-friendly**: CLI-first design works perfectly with AI coding agents
+- **Branch-aware**: Issues can follow your branch workflow
+- **Always in sync**: Auto-syncs with your commits
+
+## Why Beads?
+
+✨ **AI-Native Design**
+- Built specifically for AI-assisted development workflows
+- CLI-first interface works seamlessly with AI coding agents
+- No context switching to web UIs
+
+🚀 **Developer Focused**
+- Issues live in your repo, right next to your code
+- Works offline, syncs when you push
+- Fast, lightweight, and stays out of your way
+
+🔧 **Git Integration**
+- Automatic sync with git commits
+- Branch-aware issue tracking
+- Dolt-native three-way merge resolution
+
+## Get Started with Beads
+
+Try Beads in your own projects:
+
+```bash
+# Install Beads
+curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+
+# Initialize in your repo
+bd init
+
+# Create your first issue
+bd create "Try out Beads"
+```
+
+## Learn More
+
+- **Documentation**: [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
+- **Quick Start Guide**: Run `bd quickstart`
+- **Examples**: [github.com/steveyegge/beads/examples](https://github.com/steveyegge/beads/tree/main/examples)
+
+---
+
+*Beads: Issue tracking that moves at the speed of thought* ⚡

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,54 @@
+# Beads Configuration File
+# This file configures default behavior for all bd commands in this repository
+# All settings can also be set via environment variables (BD_* prefix)
+# or overridden with command-line flags
+
+# Issue prefix for this repository (used by bd init)
+# If not set, bd init will auto-detect from directory name
+# Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
+# issue-prefix: ""
+
+# Use no-db mode: JSONL-only, no Dolt database
+# When true, bd will use .beads/issues.jsonl as the source of truth
+# no-db: false
+
+# Enable JSON output by default
+# json: false
+
+# Feedback title formatting for mutating commands (create/update/close/dep/edit)
+# 0 = hide titles, N > 0 = truncate to N characters
+# output:
+#   title-length: 255
+
+# Default actor for audit trails (overridden by BEADS_ACTOR or --actor)
+# actor: ""
+
+# Export events (audit trail) to .beads/events.jsonl on each flush/sync
+# When enabled, new events are appended incrementally using a high-water mark.
+# Use 'bd export --events' to trigger manually regardless of this setting.
+# events-export: false
+
+# Multi-repo configuration (experimental - bd-307)
+# Allows hydrating from multiple repositories and routing writes to the correct database
+# repos:
+#   primary: "."  # Primary repo (where this database lives)
+#   additional:   # Additional repos to hydrate from (read-only)
+#     - ~/beads-planning  # Personal planning repo
+#     - ~/work-planning   # Work planning repo
+
+# JSONL backup (periodic export for off-machine recovery)
+# Auto-enabled when a git remote exists. Override explicitly:
+# backup:
+#   enabled: false     # Disable auto-backup entirely
+#   interval: 15m      # Minimum time between auto-exports
+#   git-push: false    # Disable git push (export locally only)
+#   git-repo: ""       # Separate git repo for backups (default: project repo)
+
+# Integration settings (access with 'bd config get/set')
+# These are stored in the database, not in this file:
+# - jira.url
+# - jira.project
+# - linear.url
+# - linear.api-key
+# - github.org
+# - github.repo

--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-checkout'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run post-merge "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-merge'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-commit'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run pre-push "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-push'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'prepare-commit-msg' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'prepare-commit-msg'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,7 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "embedded",
+  "dolt_database": "stackd",
+  "project_id": "b716b961-a7da-4268-80be-f923035551c6"
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,11 +54,33 @@ stackd/
 - **Frontend:** Keep Preact components small and focused. CSS modules per component. No external UI libraries.
 - **Comments:** Only comment non-obvious logic. Self-documenting names are preferred.
 
-## Pre-Push Workflow
+## Pre-Push & Pre-Completion Code Review
 
-- **Always run `codex:review` before any `git push`.** No exceptions — including bugfixes, doc updates, and "trivial" changes.
-- Address every finding from the review (or explicitly justify why a finding is not actionable) before pushing.
-- If `codex:review` is skipped or fails, the push is not allowed; fix the issues locally and re-run the review until clean.
+**MANDATORY for every agent (Claude, Copilot CLI, Codex, Cursor, etc.) — no exceptions, including bugfixes, doc updates, dependency bumps, and "trivial" changes.**
+
+- Before declaring a task complete **and** before any `git push`, run a code review using your client's review skill:
+  - Copilot CLI: `/copilot:review`
+  - Codex CLI: `/codex:review`
+  - Any equivalent automated reviewer the client provides.
+- Address every finding from the review, or explicitly justify in writing why a finding is not actionable, before pushing or marking the task done.
+- If the review is skipped or fails, the push / task-complete state is **not** allowed; fix the issues locally and re-run the review until clean.
+
+## Issue Tracking — Beads
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` for full workflow context.
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work atomically
+bd close <id>         # Complete work
+bd dolt push          # Push beads data to remote
+```
+
+Rules:
+- Use `bd` for all task tracking. Do not maintain TODO lists in markdown.
+- Use `bd remember` for persistent knowledge — do not create `MEMORY.md` files.
+- Session-close workflow (file follow-ups → quality gates → `git pull --rebase` → `bd dolt push` → `git push` → verify "up to date with origin") is mandatory; see `CLAUDE.md` / `AGENTS.md` for the full checklist.
 
 ## Key Data Flow
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 **/.DS_Store
 .claude/
 .superset/
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# Agent Instructions
+
+This project uses **bd** (beads) for issue tracking. Run `bd prime` for full workflow context.
+
+## Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work atomically
+bd close <id>         # Complete work
+bd dolt push          # Push beads data to remote
+```
+
+## Non-Interactive Shell Commands
+
+**ALWAYS use non-interactive flags** with file operations to avoid hanging on confirmation prompts.
+
+Shell commands like `cp`, `mv`, and `rm` may be aliased to include `-i` (interactive) mode on some systems, causing the agent to hang indefinitely waiting for y/n input.
+
+**Use these forms instead:**
+```bash
+# Force overwrite without prompting
+cp -f source dest           # NOT: cp source dest
+mv -f source dest           # NOT: mv source dest
+rm -f file                  # NOT: rm file
+
+# For recursive operations
+rm -rf directory            # NOT: rm -r directory
+cp -rf source dest          # NOT: cp -r source dest
+```
+
+**Other commands that may prompt:**
+- `scp` - use `-o BatchMode=yes` for non-interactive
+- `ssh` - use `-o BatchMode=yes` to fail instead of prompting
+- `apt-get` - use `-y` flag
+- `brew` - use `HOMEBREW_NO_AUTO_UPDATE=1` env var
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,18 @@
 
 This project uses **bd** (beads) for issue tracking. Run `bd prime` for full workflow context.
 
+## Pre-Push & Pre-Completion Code Review
+
+**MANDATORY for every agent (Claude, Copilot CLI, Codex, Cursor, etc.):**
+
+- Before declaring a task complete **and** before any `git push`, run a code review using your client's review skill. Examples:
+  - Copilot CLI: `/copilot:review`
+  - Codex CLI: `/codex:review`
+  - Any equivalent automated reviewer the client provides.
+- Address every finding, or explicitly justify in writing why a finding is not actionable, before pushing or marking the task done.
+- If the review is skipped or fails, the push / task-complete state is **not** allowed. Fix the issues locally and re-run the review until clean.
+- This applies to bugfixes, doc-only changes, dependency bumps, and "trivial" edits — no exceptions.
+
 ## Quick Reference
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# Project Instructions for AI Agents
+
+This file provides instructions and context for AI coding agents working on this project.
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->
+
+
+## Build & Test
+
+_Add your build and test commands here_
+
+```bash
+# Example:
+# npm install
+# npm test
+```
+
+## Architecture Overview
+
+_Add a brief overview of your project architecture_
+
+## Conventions & Patterns
+
+_Add your project-specific conventions here_

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,20 +50,78 @@ bd close <id>         # Complete work
 <!-- END BEADS INTEGRATION -->
 
 
+## Pre-Push & Pre-Completion Code Review
+
+**MANDATORY for every agent (Claude, Copilot CLI, Codex, Cursor, etc.):**
+
+- Before declaring a task complete **and** before any `git push`, run a code review using your client's review skill. Examples:
+  - Copilot CLI: `/copilot:review`
+  - Codex CLI: `/codex:review`
+  - Any equivalent automated reviewer the client provides.
+- Address every finding from the review, or explicitly justify in writing why a finding is not actionable, before pushing or marking the task done.
+- If the review is skipped or fails, the push / task-complete state is **not** allowed. Fix the issues locally and re-run the review until clean.
+- This applies to bugfixes, doc-only changes, dependency bumps, and "trivial" edits — no exceptions.
+
 ## Build & Test
 
-_Add your build and test commands here_
-
 ```bash
-# Example:
-# npm install
-# npm test
+# 1. Build frontend first — Go embeds internal/ui/dist via //go:embed
+cd internal/ui && npm install && npm run build && cd ../..
+
+# 2. Go binary (run from repo root)
+go build ./...
+go vet  ./...
+go test ./...
+
+# 3. Container image (multi-stage: node → go → alpine; runs from repo root)
+docker build -t stackd:dev -f dockerfile .
 ```
+
+`internal/ui/dist/` is gitignored and embedded via `embed.FS` from `internal/ui/ui.go`. The UI **must** be built before any Go command that loads the embed package on a fresh checkout, otherwise `go build` fails with `pattern dist/...: no matching files found`. The Dockerfile handles this automatically (node stage runs before the go stage).
 
 ## Architecture Overview
 
-_Add a brief overview of your project architecture_
+stackd is a single-binary GitOps daemon for Docker Compose stacks.
+
+```
+main()
+  └─ setupSSH()                          # Write ssh config to /tmp/stackd-ssh
+  └─ New Store / New Docker Client
+  └─ runStacksSync()                     # Startup: discover & apply all stacks
+  └─ Start HTTP server (goroutine)       # Dashboard + REST API + SSE logs
+  └─ Main loop (ticker + syncTrigger):
+       └─ syncRepo()                     # fetch → compare SHA → pull → runStacksSync
+            └─ applyStack()              # docker compose up -d (or infisical run …)
+       └─ refreshContainers()            # Update container state in Store
+```
+
+Layout (see `.github/copilot-instructions.md` for the full tree and tech stack):
+
+| Path | Role |
+|---|---|
+| `main.go` | Application entrypoint, sync loop, Infisical wrapper, startup |
+| `internal/state/` | Thread-safe in-memory state store |
+| `internal/git/` | Git operations (`execpg`-wrapped, hardened SSH) |
+| `internal/execpg/` | `exec.Cmd` helper that kills the whole process group on context cancel — fixes subprocess PID leaks |
+| `internal/docker/` | Docker API wrapper (container inspect, log stream) |
+| `internal/server/` | HTTP server (dashboard + REST + SSE) |
+| `internal/metrics/` | Prometheus exposition (`stackd_goroutines`, `stackd_threads`, …) |
+| `internal/ui/` | Preact frontend (built → embedded in binary) |
+| `dockerfile` | 3-stage: node → go → alpine |
+| `.github/copilot-instructions.md` | Canonical project context, design system, delivery agents |
+| `.github/agents/` | Specialized delivery agents (per-area scope) |
+| `docs/` | User-facing documentation |
 
 ## Conventions & Patterns
 
-_Add your project-specific conventions here_
+The full source of truth is `.github/copilot-instructions.md`. Highlights:
+
+- **Go:** Standard library preferred. New packages go under `internal/`. Wrap errors with context (`fmt.Errorf("syncRepo %s: %w", name, err)`).
+- **Logging:** New code uses `log/slog` (structured, JSON). Do not use `log.Printf`.
+- **Context:** All long-running operations accept and respect a `context.Context` with a deadline. Never use `context.Background()` without a timeout in a goroutine.
+- **Subprocesses:** Use `internal/execpg.CommandContext` instead of `exec.CommandContext` for any command that may spawn grandchildren (ssh, docker compose, infisical, …). This sets `Setpgid=true` and SIGKILLs the whole group on cancel — required to avoid PID leaks (root cause of past `runtime: newosproc EAGAIN` crashes).
+- **Concurrency:** All shared state goes through `internal/state.Store`. No direct mutation of shared variables outside the store.
+- **Testing:** Table-driven `_test.go` files alongside new code. Use `t.Cleanup` for teardown.
+- **Frontend:** Small focused Preact components, CSS modules per component, no external UI libraries. Dark only (`#0d1117`). `JetBrains Mono` for data/logs; `DM Sans` for labels. Status colors are reserved (`#3fb950`/`#f85149`/`#d29922`/`#58a6ff`).
+- **Comments:** Only when something is non-obvious. Self-documenting names first.
+- **Module name:** `stackd` (`go.mod` line 1).


### PR DESCRIPTION
Make every agent (Claude, Copilot CLI, Codex, Cursor, …) read the same expectations regardless of which client invoked it.

## Changes

- **`CLAUDE.md`** — fill out previously-empty Build/Test, Architecture, and Conventions sections (no longer placeholders) and add a **Pre-Push & Pre-Completion Code Review** section: every agent must run `/copilot:review` or `/codex:review` (or client equivalent) before declaring a task done **and** before any `git push`. No exceptions.
- **`AGENTS.md`** — add the same Pre-Push & Pre-Completion Code Review section at the top.
- **`.github/copilot-instructions.md`** — replace the Codex-specific Pre-Push Workflow with the harmonized 'every agent' wording, and add an **Issue Tracking — Beads** section so Copilot CLI agents see the same `bd` workflow as Claude.

## Notes

- Build instructions document the UI-first ordering: `internal/ui/dist` is embedded via `//go:embed`, so a fresh checkout needs the npm build before any Go command. Docker build returns to the repo root.
- Codex review: clean (after fixing two P2 findings on the build snippet).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>